### PR TITLE
consideration for node

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,10 @@ let dependencies: [Package.Dependency] = [
     .Package(url: "https://github.com/czechboy0/Socks.git", majorVersion: 0, minor: 10),
 
     //CoreComponents
-    .Package(url: "https://github.com/qutheory/core.git", majorVersion: 0, minor: 3)
+    .Package(url: "https://github.com/vapor/core.git", majorVersion: 0, minor: 3),
+
+    //Node
+    .Package(url: "https://github.com/vapor/node.git", majorVersion: 0, minor: 3)
 ]
 
 let package = Package(

--- a/Sources/HTTP/Models/Request/Request.swift
+++ b/Sources/HTTP/Models/Request/Request.swift
@@ -1,4 +1,5 @@
 import URI
+import Node
 
 public final class Request: Message {
     // TODO: public set for head request in application, serializer should change it, avoid exposing to end user
@@ -7,7 +8,7 @@ public final class Request: Message {
     public var uri: URI
     public let version: Version
 
-    public var parameters: [String: String] = [:]
+    public var parameters: Node = [:]
 
     public convenience init(method: Method, uri: String, version: Version = Version(major: 1, minor: 1), headers: [HeaderKey: String] = [:], body: Body = .data([])) throws {
         let uri = try URI(uri)


### PR DESCRIPTION
Seeing how this feels over `[String: String]`

Benefits:

```Swift
let id = try request.params.extract("id") as Int // any node convertible
// or older style
guard let id = request.parameters["id"].int else { throw or something }
```