### PR TITLE
Added peerAddress property to Stream

### DIFF
--- a/Sources/HTTP/Models/Messages/Message.swift
+++ b/Sources/HTTP/Models/Messages/Message.swift
@@ -46,4 +46,9 @@ extension Message {
         guard let value = headers["Connection"] else { return true }
         return !value.contains("close")
     }
+    
+    /// The address of the remote peer of this message.
+    public var peerAddress: String? {
+        return storage["peerAddress"] as? String
+    }
 }

--- a/Sources/HTTP/Models/Messages/Message.swift
+++ b/Sources/HTTP/Models/Messages/Message.swift
@@ -13,11 +13,15 @@ public class Message {
     public var body: Body
 
     public var storage: [String: Any] = [:]
+    
+    /// The address of the remote peer of this message.
+    public var peerAddress: String?
 
     public convenience required init(
         startLineComponents: (BytesSlice, BytesSlice, BytesSlice),
         headers: [HeaderKey: String],
-        body: Body
+        body: Body,
+        peerAddress: String?
     ) throws {
         var startLine = startLineComponents.0.string
         startLine += " "
@@ -25,13 +29,14 @@ public class Message {
         startLine += " "
         startLine += startLineComponents.2.string
 
-        self.init(startLine: startLine, headers: headers,body: body)
+        self.init(startLine: startLine, headers: headers, body: body, peerAddress: peerAddress)
     }
 
-    public init(startLine: String, headers: [HeaderKey: String], body: Body) {
+    public init(startLine: String, headers: [HeaderKey: String], body: Body, peerAddress: String?) {
         self.startLine = startLine
         self.headers = headers
         self.body = body
+        self.peerAddress = peerAddress
     }
 }
 
@@ -45,10 +50,5 @@ extension Message {
         // HTTP 1.1 defaults to true unless explicitly passed `Connection: close`
         guard let value = headers["Connection"] else { return true }
         return !value.contains("close")
-    }
-    
-    /// The address of the remote peer of this message.
-    public var peerAddress: String? {
-        return storage["peerAddress"] as? String
     }
 }

--- a/Sources/HTTP/Models/Request/Request.swift
+++ b/Sources/HTTP/Models/Request/Request.swift
@@ -16,7 +16,8 @@ public final class Request: Message {
                 uri: URI,
                 version: Version = Version(major: 1, minor: 1),
                 headers: [HeaderKey: String] = [:],
-                body: Body = .data([])) {
+                body: Body = .data([]),
+                peerAddress: String? = nil) {
         var headers = headers
         headers.appendHost(for: uri)
 
@@ -41,10 +42,10 @@ public final class Request: Message {
 
         let versionLine = "HTTP/\(version.major).\(version.minor)"
         let requestLine = "\(method) \(path) \(versionLine)"
-        super.init(startLine: requestLine, headers: headers, body: body)
+        super.init(startLine: requestLine, headers: headers, body: body, peerAddress: peerAddress)
     }
 
-    public convenience required init(startLineComponents: (BytesSlice, BytesSlice, BytesSlice), headers: [HeaderKey: String], body: Body) throws {
+    public convenience required init(startLineComponents: (BytesSlice, BytesSlice, BytesSlice), headers: [HeaderKey: String], body: Body, peerAddress: String?) throws {
         /**
             https://tools.ietf.org/html/rfc2616#section-5.1
 
@@ -69,7 +70,7 @@ public final class Request: Message {
         uri.scheme = uri.scheme.isEmpty ? "http" : uri.scheme
         let version = try Version.makeParsed(with: httpVersionSlice)
 
-        self.init(method: method, uri: uri, version: version, headers: headers, body: body)
+        self.init(method: method, uri: uri, version: version, headers: headers, body: body, peerAddress: peerAddress)
     }
 }
 

--- a/Sources/HTTP/Models/Response/Response.swift
+++ b/Sources/HTTP/Models/Response/Response.swift
@@ -14,20 +14,22 @@ public final class Response: Message {
         version: Version = Version(major: 1, minor: 1),
         status: Status = .ok,
         headers: [HeaderKey: String] = [:],
-        body: Body = .data([])
+        body: Body = .data([]),
+        peerAddress: String? = nil
     ) {
         self.version = version
         self.status = status
 
 
         let statusLine = "HTTP/\(version.major).\(version.minor) \(status.statusCode) \(status.reasonPhrase)"
-        super.init(startLine: statusLine, headers: headers, body: body)
+        super.init(startLine: statusLine, headers: headers, body: body, peerAddress: peerAddress)
     }
 
     public convenience required init(
         startLineComponents: (BytesSlice, BytesSlice, BytesSlice),
         headers: [HeaderKey: String],
-        body: Body
+        body: Body,
+        peerAddress: String?
     ) throws {
         let (httpVersionSlice, statusCodeSlice, reasonPhrase) = startLineComponents
         let version = try Version.makeParsed(with: httpVersionSlice)
@@ -36,7 +38,7 @@ public final class Response: Message {
         }
         let status = Status(statusCode: statusCode, reasonPhrase: reasonPhrase.string)
 
-        self.init(version: version, status: status, headers: headers, body: body)
+        self.init(version: version, status: status, headers: headers, body: body, peerAddress: peerAddress)
     }
 }
 

--- a/Sources/HTTP/Parser/HTTPParser.swift
+++ b/Sources/HTTP/Parser/HTTPParser.swift
@@ -86,11 +86,13 @@ public final class Parser<MessageType: Message>: TransferParser {
         let startLineComponents = try parseStartLine()
         let headers = try parseHeaders()
         let body = try parseBody(with: headers)
-        return try MessageType(
+        let message = try MessageType(
             startLineComponents: startLineComponents,
             headers: headers,
             body: body
         )
+        message.storage["peerAddress"] = stream.peerAddress
+        return message
     }
 
     /**

--- a/Sources/HTTP/Parser/HTTPParser.swift
+++ b/Sources/HTTP/Parser/HTTPParser.swift
@@ -89,9 +89,9 @@ public final class Parser<MessageType: Message>: TransferParser {
         let message = try MessageType(
             startLineComponents: startLineComponents,
             headers: headers,
-            body: body
+            body: body,
+            peerAddress: stream.peerAddress
         )
-        message.storage["peerAddress"] = stream.peerAddress
         return message
     }
 

--- a/Sources/Transport/Streams/FoundationStream.swift
+++ b/Sources/Transport/Streams/FoundationStream.swift
@@ -3,6 +3,12 @@
     import Foundation
 
     public class FoundationStream: NSObject, Stream, ClientStream, Foundation.StreamDelegate {
+        
+        public var peerAddress: String {
+            //treating as IPv4 for now
+            return "\(host):\(port)"
+        }
+
         public enum Error: Swift.Error {
             case unableToCompleteReadOperation
             case unableToCompleteWriteOperation

--- a/Sources/Transport/Streams/Socks+Stream.swift
+++ b/Sources/Transport/Streams/Socks+Stream.swift
@@ -2,6 +2,25 @@ import Core
 import SocksCore
 
 extension TCPInternetSocket: Stream {
+    
+    public var peerAddress: String {
+        let address = self.address
+        switch try! address.addressFamily() {
+        case .inet:
+            // IPv4: e.g. "10.0.0.141:63234"
+            return "\(address.ipString()):\(address.port)"
+        case .inet6:
+            // IPv6: e.g. "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443"
+            return "[\(address.ipString())]:\(address.port)"
+        case .unspecified:
+            //input by user, system never resolves an address to .unspecified
+            //ideally, we'd do a quick analysis of whether it's a hostname (treat as IPv4),
+            //or IPv4 literal (treat as IPv4) or IPv6 literal (treat as IPv6).
+            //most common are the first two, for simplicity we'll treat is at IPv4 always for now.
+            return "\(address.ipString()):\(address.port)"
+        }
+    }
+
     public func setTimeout(_ timeout: Double) throws {
         sendingTimeout = timeval(seconds: timeout)
     }

--- a/Sources/Transport/Streams/Socks+Stream.swift
+++ b/Sources/Transport/Streams/Socks+Stream.swift
@@ -5,7 +5,10 @@ extension TCPInternetSocket: Stream {
     
     public var peerAddress: String {
         let address = self.address
-        switch try! address.addressFamily() {
+        guard let addressFamily = try? address.addressFamily() else {
+            return "unknown address family"
+        }
+        switch addressFamily {
         case .inet:
             // IPv4: e.g. "10.0.0.141:63234"
             return "\(address.ipString()):\(address.port)"

--- a/Sources/Transport/Streams/Stream.swift
+++ b/Sources/Transport/Streams/Stream.swift
@@ -20,6 +20,12 @@ public protocol Stream: class {
 
     // Optional, performance
     func receive() throws -> Byte?
+    
+    /// The address of the remote end of the stream.
+    /// Whatever makes sense in the context of the particular stream type.
+    /// E.g. a IPv4 stream will have the concatination of the IP address
+    /// and port: "10.0.0.130:63394"
+    var peerAddress: String { get }
 }
 
 extension Stream {

--- a/Sources/Transport/Streams/StreamBuffer.swift
+++ b/Sources/Transport/Streams/StreamBuffer.swift
@@ -9,6 +9,11 @@ import Core
     Send calls are buffered until `flush()` is called.
 */
 public final class StreamBuffer: Stream {
+    
+    public var peerAddress: String {
+        return stream.peerAddress
+    }
+
     private let stream: Stream
     private let size: Int
 

--- a/Tests/HTTP/HTTPParsingTests.swift
+++ b/Tests/HTTP/HTTPParsingTests.swift
@@ -74,6 +74,9 @@ class HTTPParsingTests: XCTestCase {
 }
 
 final class TestStream: Transport.Stream {
+
+    public var peerAddress: String = "1.2.3.4:5678"
+
     var closed: Bool
     var buffer: Bytes
     var timeout: Double = -1

--- a/Tests/HTTP/HTTPRequestTests.swift
+++ b/Tests/HTTP/HTTPRequestTests.swift
@@ -26,6 +26,7 @@ class HTTPRequestTests: XCTestCase {
             XCTAssertEqual(request.uri.path, "/plaintext")
             XCTAssertEqual(request.version.major, 1)
             XCTAssertEqual(request.version.minor, 1)
+            XCTAssertEqual(request.peerAddress, "1.2.3.4:5678")
         } catch {
             XCTFail("\(error)")
         }

--- a/Tests/SMTP/SMTPTestStream.swift
+++ b/Tests/SMTP/SMTPTestStream.swift
@@ -30,6 +30,11 @@ private let SMTPReplies: [String: String] = [
 ]
 
 final class SMTPTestStream: Transport.ClientStream, Transport.Stream {
+
+    public var peerAddress: String {
+        return "\(host):\(port)"
+    }
+
     var closed: Bool
     var buffer: Bytes
 

--- a/Tests/Transport/StreamBufferTests.swift
+++ b/Tests/Transport/StreamBufferTests.swift
@@ -71,6 +71,9 @@ class StreamBufferTests: XCTestCase {
 
 
 final class TestStream: Transport.Stream {
+
+    var peerAddress: String = "1.2.3.4:5678"
+
     var closed: Bool
     var buffer: Bytes
     var timeout: Double = -1

--- a/Tests/WebSockets/WebSocketParsingTests.swift
+++ b/Tests/WebSockets/WebSocketParsingTests.swift
@@ -335,6 +335,9 @@ class WebSocketKeyTests: XCTestCase {
 }
 
 final class TestStream: Transport.Stream {
+    
+    var peerAddress: String = "1.2.3.4:5678"
+
     var closed: Bool
     var buffer: Bytes
 


### PR DESCRIPTION
This aims to fix https://github.com/vapor/vapor/issues/538, as each Stream will now have a chance to vend a address string. I'm open to discussing the name, this just felt correct to me right now.