### PR TITLE
Piping TLS.Config through

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,7 @@ let dependencies: [Package.Dependency] = [
     .Package(url: "https://github.com/vapor/crypto.git", majorVersion: 0, minor: 2),
 
     // Secure Sockets
-    .Package(url: "https://github.com/vapor/tls.git", majorVersion: 0, minor: 6),
-
-    // Sockets, used by the built in HTTP server
-    .Package(url: "https://github.com/czechboy0/Socks.git", majorVersion: 0, minor: 12),
+    .Package(url: "https://github.com/vapor/tls.git", majorVersion: 0, minor: 7),
 
     // CoreComponents
     .Package(url: "https://github.com/vapor/core.git", majorVersion: 0, minor: 4),

--- a/Sources/HTTP/Models/Client/HTTP+Client.swift
+++ b/Sources/HTTP/Models/Client/HTTP+Client.swift
@@ -71,7 +71,7 @@ public final class Client<
         }
 
         if request.uri.scheme.isEmpty {
-            guard request.uri.scheme.securityLayer == securityLayer else { throw ClientError.invalidRequestScheme }
+            guard request.uri.scheme.securityLayer.isSecure == securityLayer.isSecure else { throw ClientError.invalidRequestScheme }
         }
 
         if let requestPort = request.uri.port {

--- a/Sources/HTTP/Program/Program.swift
+++ b/Sources/HTTP/Program/Program.swift
@@ -12,7 +12,7 @@ extension Program {
     public static func make(
         host: String? = nil,
         port: Int? = nil,
-        securityLayer: SecurityLayer = .defaultTLS()
+        securityLayer: SecurityLayer = .tls(nil)
     ) throws -> Self {
         let host = host ?? "0.0.0.0"
         let port = port ?? securityLayer.port()

--- a/Sources/HTTP/Program/Program.swift
+++ b/Sources/HTTP/Program/Program.swift
@@ -12,11 +12,23 @@ extension Program {
     public static func make(
         host: String? = nil,
         port: Int? = nil,
-        securityLayer: SecurityLayer = .tls
+        securityLayer: SecurityLayer = .tls(TLSConfig())
     ) throws -> Self {
         let host = host ?? "0.0.0.0"
-        let port = port ?? (securityLayer == .tls ? 443 : 80)
+        let port = port ?? securityLayer.port()
         return try Self(host: host, port: port, securityLayer: securityLayer)
+    }
+}
+
+extension SecurityLayer {
+    
+    func port() -> Int {
+        switch self {
+        case .none:
+            return 80
+        case .tls(_):
+            return 443
+        }
     }
 }
 

--- a/Sources/HTTP/Program/Program.swift
+++ b/Sources/HTTP/Program/Program.swift
@@ -12,7 +12,7 @@ extension Program {
     public static func make(
         host: String? = nil,
         port: Int? = nil,
-        securityLayer: SecurityLayer = .tls(TLSConfig())
+        securityLayer: SecurityLayer = .defaultTLS()
     ) throws -> Self {
         let host = host ?? "0.0.0.0"
         let port = port ?? securityLayer.port()
@@ -21,7 +21,6 @@ extension Program {
 }
 
 extension SecurityLayer {
-    
     func port() -> Int {
         switch self {
         case .none:

--- a/Sources/SMTP/Client/SMTPClient+Convenience.swift
+++ b/Sources/SMTP/Client/SMTPClient+Convenience.swift
@@ -8,7 +8,7 @@ extension SMTPClient {
          https://app.sendgrid.com/settings/credentials
     */
     public static func makeSendGridClient() throws -> SMTPClient {
-        return try SMTPClient(host: "smtp.sendgrid.net", port: 465, securityLayer: .defaultTLS())
+        return try SMTPClient(host: "smtp.sendgrid.net", port: 465, securityLayer: .tls(nil))
     }
 
     /*
@@ -19,6 +19,6 @@ extension SMTPClient {
          pass: Your Gmail or Google Apps email password
     */
     public static func makeGmailClient() throws -> SMTPClient {
-        return try SMTPClient(host: "smtp.gmail.com", port: 465, securityLayer: .defaultTLS())
+        return try SMTPClient(host: "smtp.gmail.com", port: 465, securityLayer: .tls(nil))
     }
 }

--- a/Sources/SMTP/Client/SMTPClient+Convenience.swift
+++ b/Sources/SMTP/Client/SMTPClient+Convenience.swift
@@ -8,7 +8,7 @@ extension SMTPClient {
          https://app.sendgrid.com/settings/credentials
     */
     public static func makeSendGridClient() throws -> SMTPClient {
-        return try SMTPClient(host: "smtp.sendgrid.net", port: 465, securityLayer: .tls(TLSConfig()))
+        return try SMTPClient(host: "smtp.sendgrid.net", port: 465, securityLayer: .defaultTLS())
     }
 
     /*
@@ -19,6 +19,6 @@ extension SMTPClient {
          pass: Your Gmail or Google Apps email password
     */
     public static func makeGmailClient() throws -> SMTPClient {
-        return try SMTPClient(host: "smtp.gmail.com", port: 465, securityLayer: .tls(TLSConfig()))
+        return try SMTPClient(host: "smtp.gmail.com", port: 465, securityLayer: .defaultTLS())
     }
 }

--- a/Sources/SMTP/Client/SMTPClient+Convenience.swift
+++ b/Sources/SMTP/Client/SMTPClient+Convenience.swift
@@ -1,3 +1,4 @@
+import Transport
 
 extension SMTPClient {
     /*
@@ -7,7 +8,7 @@ extension SMTPClient {
          https://app.sendgrid.com/settings/credentials
     */
     public static func makeSendGridClient() throws -> SMTPClient {
-        return try SMTPClient(host: "smtp.sendgrid.net", port: 465, securityLayer: .tls)
+        return try SMTPClient(host: "smtp.sendgrid.net", port: 465, securityLayer: .tls(TLSConfig()))
     }
 
     /*
@@ -18,6 +19,6 @@ extension SMTPClient {
          pass: Your Gmail or Google Apps email password
     */
     public static func makeGmailClient() throws -> SMTPClient {
-        return try SMTPClient(host: "smtp.gmail.com", port: 465, securityLayer: .tls)
+        return try SMTPClient(host: "smtp.gmail.com", port: 465, securityLayer: .tls(TLSConfig()))
     }
 }

--- a/Sources/Transport/Streams/FoundationStream.swift
+++ b/Sources/Transport/Streams/FoundationStream.swift
@@ -100,14 +100,14 @@
     }
 
     extension FoundationStream {
-        public func upgradeSSL(config: TLS.Config) {
+        public func upgradeSSL(config: TLS.Config?) {
             [input, output].forEach { stream in stream.upgradeSSL(config: config) }
         }
     }
 
     extension Foundation.Stream {
         @discardableResult
-        func upgradeSSL(config: TLS.Config) -> Bool {
+        func upgradeSSL(config: TLS.Config?) -> Bool {
             //TODO: apply TLS.Config's properties to the stream
             return setProperty(Foundation.StreamSocketSecurityLevel.negotiatedSSL.rawValue,
                                forKey: Foundation.Stream.PropertyKey.socketSecurityLevelKey)

--- a/Sources/Transport/Streams/FoundationStream.swift
+++ b/Sources/Transport/Streams/FoundationStream.swift
@@ -84,7 +84,7 @@
         // MARK: Connect
 
         public func connect() throws -> Stream {
-            if securityLayer == .tls {
+            if case .tls(_) = securityLayer {
                 upgradeSSL()
             }
             input.open()

--- a/Sources/Transport/Streams/FoundationStream.swift
+++ b/Sources/Transport/Streams/FoundationStream.swift
@@ -84,8 +84,8 @@
         // MARK: Connect
 
         public func connect() throws -> Stream {
-            if case .tls(_) = securityLayer {
-                upgradeSSL()
+            if case .tls(let config) = securityLayer {
+                upgradeSSL(config: config)
             }
             input.open()
             output.open()
@@ -100,14 +100,15 @@
     }
 
     extension FoundationStream {
-        public func upgradeSSL() {
-            [input, output].forEach { stream in stream.upgradeSSL() }
+        public func upgradeSSL(config: TLS.Config) {
+            [input, output].forEach { stream in stream.upgradeSSL(config: config) }
         }
     }
 
     extension Foundation.Stream {
         @discardableResult
-        func upgradeSSL() -> Bool {
+        func upgradeSSL(config: TLS.Config) -> Bool {
+            //TODO: apply TLS.Config's properties to the stream
             return setProperty(Foundation.StreamSocketSecurityLevel.negotiatedSSL.rawValue,
                                forKey: Foundation.Stream.PropertyKey.socketSecurityLevelKey)
         }

--- a/Sources/Transport/Streams/ProgramStream/ProgramStream.swift
+++ b/Sources/Transport/Streams/ProgramStream/ProgramStream.swift
@@ -1,4 +1,4 @@
-@_exported import struct TLS.TLSConfig
+@_exported import struct TLS.Config
 
 public enum ProgramStreamError: Error {
     /**
@@ -23,7 +23,11 @@ extension ProgramStream {
 
 public enum SecurityLayer {
     case none
-    case tls(TLSConfig)
+    case tls(TLS.Config)
+    
+    public static func defaultTLS() -> SecurityLayer {
+        return .tls(TLS.Config())
+    }
 }
 
 extension SecurityLayer: Equatable {
@@ -42,7 +46,7 @@ extension SecurityLayer: Equatable {
 extension String {
     public var securityLayer: SecurityLayer {
         if self == "https" || self == "wss" {
-            return .tls(TLSConfig())
+            return .defaultTLS()
         }
 
         return .none

--- a/Sources/Transport/Streams/ProgramStream/ProgramStream.swift
+++ b/Sources/Transport/Streams/ProgramStream/ProgramStream.swift
@@ -1,4 +1,4 @@
-@_exported import struct TLS.Config
+@_exported import class TLS.Config
 
 public enum ProgramStreamError: Error {
     /**
@@ -23,11 +23,7 @@ extension ProgramStream {
 
 public enum SecurityLayer {
     case none
-    case tls(TLS.Config)
-    
-    public static func defaultTLS() -> SecurityLayer {
-        return .tls(TLS.Config())
-    }
+    case tls(TLS.Config?)
 }
 
 extension SecurityLayer: Equatable {
@@ -46,7 +42,7 @@ extension SecurityLayer: Equatable {
 extension String {
     public var securityLayer: SecurityLayer {
         if self == "https" || self == "wss" {
-            return .defaultTLS()
+            return .tls(nil)
         }
 
         return .none

--- a/Sources/Transport/Streams/ProgramStream/ProgramStream.swift
+++ b/Sources/Transport/Streams/ProgramStream/ProgramStream.swift
@@ -1,3 +1,5 @@
+@_exported import struct TLS.TLSConfig
+
 public enum ProgramStreamError: Error {
     /**
         Visit https://github.com/qutheory/vapor-tls
@@ -20,13 +22,27 @@ extension ProgramStream {
 }
 
 public enum SecurityLayer {
-    case none, tls
+    case none
+    case tls(TLSConfig)
+}
+
+extension SecurityLayer: Equatable {
+    public static func ==(lhs: SecurityLayer, rhs: SecurityLayer) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .none):
+            return true
+        case (.tls(_), .tls(_)):
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 extension String {
     public var securityLayer: SecurityLayer {
         if self == "https" || self == "wss" {
-            return .tls
+            return .tls(TLSConfig())
         }
 
         return .none

--- a/Sources/Transport/Streams/Socks+Stream.swift
+++ b/Sources/Transport/Streams/Socks+Stream.swift
@@ -74,8 +74,8 @@ public final class TCPClientStream: TCPProgramStream, ClientStream  {
         switch securityLayer {
         case .none:
             return stream
-        case .tls:
-            let secure = try stream.makeSecret(mode: .client)
+        case .tls(let config):
+            let secure = try stream.makeSecret(mode: .client, config: config)
             try secure.stream.connect(servername: host)
             return secure
         }
@@ -119,11 +119,13 @@ public final class TLSSocket<Socket: SocksCore.TCPInternetSocket> {
     public convenience init(
         mode: TLS.Mode,
         socket: Socket,
+        config: TLSConfig,
         certificates: TLS.Certificates = .none
     ) throws {
         let stream = try TLS.Stream(
             mode: mode,
             socket: socket.descriptor,
+            config: config,
             certificates: certificates
         )
         self.init(stream: stream, socket: socket)
@@ -173,11 +175,13 @@ extension TCPInternetSocket {
      */
     public func makeSecret(
         mode: TLS.Mode = .client,
+        config: TLSConfig = TLSConfig(),
         certificates: TLS.Certificates = .none
     ) throws -> TLSSocket<TCPInternetSocket> {
         return try TLSSocket(
             mode: mode,
             socket: self,
+            config: config,
             certificates: certificates
         )
     }

--- a/Sources/Transport/Streams/Socks+Stream.swift
+++ b/Sources/Transport/Streams/Socks+Stream.swift
@@ -119,14 +119,12 @@ public final class TLSSocket<Socket: SocksCore.TCPInternetSocket> {
     public convenience init(
         mode: TLS.Mode,
         socket: Socket,
-        config: TLSConfig,
-        certificates: TLS.Certificates = .none
+        config: TLS.Config
     ) throws {
         let stream = try TLS.Stream(
             mode: mode,
             socket: socket.descriptor,
-            config: config,
-            certificates: certificates
+            config: config
         )
         self.init(stream: stream, socket: socket)
     }
@@ -175,14 +173,12 @@ extension TCPInternetSocket {
      */
     public func makeSecret(
         mode: TLS.Mode = .client,
-        config: TLSConfig = TLSConfig(),
-        certificates: TLS.Certificates = .none
+        config: TLS.Config = Config()
     ) throws -> TLSSocket<TCPInternetSocket> {
         return try TLSSocket(
             mode: mode,
             socket: self,
-            config: config,
-            certificates: certificates
+            config: config
         )
     }
 }

--- a/Sources/Transport/Streams/Socks+Stream.swift
+++ b/Sources/Transport/Streams/Socks+Stream.swift
@@ -137,15 +137,12 @@ extension TLS.Socket: Stream {
     }
 }
 
-extension SecurityLayer: Equatable {
-    public static func ==(lhs: SecurityLayer, rhs: SecurityLayer) -> Bool {
-        switch (lhs, rhs) {
-        case (.none, .none):
-            return true
-        case (.none, .tls), (.tls, .none):
+extension SecurityLayer {
+    public var isSecure: Bool {
+        guard case .tls = self else {
             return false
-        case (.tls(_), .tls(_)):
-            return true
         }
+
+        return true
     }
 }

--- a/Sources/Transport/Streams/Socks+Stream.swift
+++ b/Sources/Transport/Streams/Socks+Stream.swift
@@ -70,13 +70,21 @@ import TLS
 
 public final class TCPClientStream: TCPProgramStream, ClientStream  {
     public func connect() throws -> Stream {
-        try stream.connect()
         switch securityLayer {
         case .none:
+            try stream.connect()
             return stream
-        case .tls(let config):
-            let secure = try stream.makeSecret(mode: .client, config: config)
-            try secure.stream.connect(servername: host)
+        case .tls(let provided):
+            let config: Config
+            if let c = provided {
+                config = c
+            } else {
+                let context = try Context(mode: .client)
+                config = try Config(context: context)
+            }
+
+            let secure = try TLS.Socket(config: config, socket: stream)
+            try secure.connect(servername: host)
             return secure
         }
     }
@@ -91,94 +99,40 @@ public final class TCPServerStream: TCPProgramStream, ServerStream {
     }
 
     public func accept() throws -> Stream {
-        let next = try stream.accept()
+
         switch securityLayer {
         case .none:
-            return next
-        case .tls:
-            let secure = try next.makeSecret(mode: .server)
-            try secure.stream.accept()
+            return try stream.accept()
+        case .tls(let provided):
+            let config: Config
+            if let c = provided {
+                config = c
+            } else {
+                let context = try Context(mode: .server)
+                config = try Config(context: context)
+            }
+
+            let secure = try TLS.Socket(config: config, socket: stream)
+            try secure.accept()
             return secure
         }
     }
 }
 
-import TLS
-import SocksCore
-import libc
-
-public final class TLSSocket<Socket: SocksCore.TCPInternetSocket> {
-    public let stream: TLS.Stream
-    public let socket: Socket
-
-    public init(stream: TLS.Stream, socket: Socket) {
-        self.stream = stream
-        self.socket = socket
-    }
-
-    public convenience init(
-        mode: TLS.Mode,
-        socket: Socket,
-        config: TLS.Config
-    ) throws {
-        let stream = try TLS.Stream(
-            mode: mode,
-            socket: socket.descriptor,
-            config: config
-        )
-        self.init(stream: stream, socket: socket)
-    }
-}
-
-/**
-    Conform TLS Stream + Underlying socket
-    to a TLS Socket.
-*/
-extension TLSSocket: Stream {
-    public func close() throws {
-        try stream.close()
-        try socket.close()
+extension TLS.Socket: Stream {
+    public func setTimeout(_ timeout: Double) throws {
+        try socket.setTimeout(timeout)
     }
 
     public var closed: Bool {
         return socket.closed
     }
 
-    public var peerAddress: String {
-        return socket.peerAddress
-    }
-
-    public func setTimeout(_ timeout: Double) throws {
-        try socket.setTimeout(timeout)
-    }
-
-    public func send(_ bytes: Bytes) throws {
-        try stream.send(bytes)
-    }
-
-    public func receive(max: Int) throws -> Bytes {
-        return try stream.receive(max: max)
-    }
-
     public func flush() throws {
         try socket.flush()
     }
-}
 
-extension TCPInternetSocket {
-    /**
-        Creates a new SSL Context and Secure Socket.
-        - parameter mode: Client or Server
-        - parameter certificates: SSL Certificates for the Server, use .none for Client
-     */
-    public func makeSecret(
-        mode: TLS.Mode = .client,
-        config: TLS.Config = Config()
-    ) throws -> TLSSocket<TCPInternetSocket> {
-        return try TLSSocket(
-            mode: mode,
-            socket: self,
-            config: config
-        )
+    public var peerAddress: String {
+        return socket.peerAddress
     }
 }

--- a/Sources/Transport/Streams/Socks+Stream.swift
+++ b/Sources/Transport/Streams/Socks+Stream.swift
@@ -136,3 +136,16 @@ extension TLS.Socket: Stream {
         return socket.peerAddress
     }
 }
+
+extension SecurityLayer: Equatable {
+    public static func ==(lhs: SecurityLayer, rhs: SecurityLayer) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .none):
+            return true
+        case (.none, .tls), (.tls, .none):
+            return false
+        case (.tls(_), .tls(_)):
+            return true
+        }
+    }
+}

--- a/Tests/SMTPTests/SMTPClientConvenienceTests.swift
+++ b/Tests/SMTPTests/SMTPClientConvenienceTests.swift
@@ -19,13 +19,21 @@ class SMTPClientConvenienceTests: XCTestCase {
         let gmail = try SMTPClient<SMTPTestStream>.makeGmailClient()
         XCTAssert(gmail.host == "smtp.gmail.com")
         XCTAssert(gmail.port == 465)
-        XCTAssert(gmail.securityLayer == .tls)
+        if case .tls = gmail.securityLayer {
+            //
+        } else {
+            XCTFail("Not TLS")
+        }
     }
 
     func testSendGrid() throws {
         let gmail = try SMTPClient<SMTPTestStream>.makeSendGridClient()
         XCTAssert(gmail.host == "smtp.sendgrid.net")
         XCTAssert(gmail.port == 465)
-        XCTAssert(gmail.securityLayer == .tls)
+        if case .tls = gmail.securityLayer {
+            //
+        } else {
+            XCTFail("Not TLS")
+        }
     }
 }

--- a/Tests/TransportTests/SockStreamTests.swift
+++ b/Tests/TransportTests/SockStreamTests.swift
@@ -90,7 +90,7 @@ class SockStreamTests: XCTestCase {
         ]
 
         schemes.forEach { scheme, securityLayer in
-            XCTAssert(scheme.securityLayer == securityLayer)
+            XCTAssert(scheme.securityLayer.isSecure == securityLayer.isSecure)
         }
     }
 


### PR DESCRIPTION
Depends on https://github.com/vapor/tls/pull/15, related to https://github.com/vapor/vapor/issues/541

You can see here that `SecurityLayer` being an enum makes it slightly difficult to work with. I suggest we add functions to easily create a `.tls(...)` case, something like 

```swift
static func defaultTLS() -> SecurityLayer {
    return .tls(TLSConfig())
}
```

for extra convenience. 

/cc @tannernelson @LoganWright 