### PR TITLE
Shim for url encoding to allow Turnstile to work

### DIFF
--- a/Sources/HTTP/Models/Request/Request.swift
+++ b/Sources/HTTP/Models/Request/Request.swift
@@ -38,12 +38,12 @@ public final class Request: Message {
         // status-line = HTTP-version SP status-code SP reason-phrase CRL
         var path = uri.path
         if let q = uri.query, !q.isEmpty {
-            let encoded = try percentEncoded(q.bytes).string
-            path += "?\(encoded)"
+            let encoded = q.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+            path += "?\(encoded ?? "")"
         }
         if let f = uri.fragment, !f.isEmpty {
-            let encoded = try percentEncoded(f.bytes).string
-            path += "#\(encoded)"
+            let encoded = f.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)
+            path += "#\(encoded ?? "")"
         }
         // Prefix w/ `/` to properly indicate that this we're not using absolute URI.
         // Absolute URIs are deprecated and MUST NOT be generated. (they should be parsed for robustness)

--- a/Tests/HTTPTests/HTTPRequestTests.swift
+++ b/Tests/HTTPTests/HTTPRequestTests.swift
@@ -118,7 +118,7 @@ class HTTPRequestTests: XCTestCase {
     }
     
     func testURLEncoding() throws {
-        // Make this test actually cover all edge cases. Different parts of the URL
+        // TODO: Make this test actually cover all edge cases. Different parts of the URL
         // have different character sets:
         // Refer to:
         // http://stackoverflow.com/a/24552028/1784384

--- a/Tests/HTTPTests/HTTPRequestTests.swift
+++ b/Tests/HTTPTests/HTTPRequestTests.swift
@@ -1,12 +1,14 @@
 import XCTest
 @testable import HTTP
+import URI
 
 class HTTPRequestTests: XCTestCase {
     static var allTests = [
         ("testParse", testParse),
         ("testParseEdgecase", testParseEdgecase),
         ("testParseXForwardedFor", testParseXForwardedFor),
-        ("testParseForwarded", testParseForwarded)
+        ("testParseForwarded", testParseForwarded),
+        ("testURLEncoding", testURLEncoding)
     ]
 
     func testParse() {
@@ -113,5 +115,18 @@ class HTTPRequestTests: XCTestCase {
         } catch {
             XCTFail("\(error)")
         }
+    }
+    
+    func testURLEncoding() throws {
+        // Make this test actually cover all edge cases. Different parts of the URL
+        // have different character sets:
+        // Refer to:
+        // http://stackoverflow.com/a/24552028/1784384
+        // https://tools.ietf.org/html/rfc3986#section-2.1
+        
+        let uri = "https://test.com/?hithere%7Chi"
+        let request = try Request(method: .get, uri: uri)
+        
+        XCTAssertEqual(request.startLine, "GET /?hithere%7Chi HTTP/1.1")
     }
 }


### PR DESCRIPTION
I'll open up an issue with more details. 