### PR TITLE
Do not change casing of headers while still matching them case-insensitive

### DIFF
--- a/Sources/HTTP/Models/Headers/Headers.swift
+++ b/Sources/HTTP/Models/Headers/Headers.swift
@@ -24,7 +24,7 @@ extension KeyAccessible where Key == HeaderKey, Value == String {
 public struct HeaderKey: Hashable, CustomStringConvertible {
     public let key: String
     public init(_ key: String) {
-        self.key = key.capitalized
+        self.key = key
     }
 }
 
@@ -38,12 +38,12 @@ extension HeaderKey: Equatable {}
 
 extension HeaderKey {
     public var hashValue: Int {
-        return key.hashValue
+        return key.lowercased().hashValue
     }
 }
 
 public func ==(lhs: HeaderKey, rhs: HeaderKey) -> Bool {
-    return lhs.key == rhs.key
+    return lhs.key.lowercased() == rhs.key.lowercased()
 }
 
 extension HeaderKey: ExpressibleByStringLiteral {


### PR DESCRIPTION
Vapor currently changes the casing of HTTP headers, so `MerchantID` becomes `Merchantid`. While this is technically correct (the HTTP standard states that headers are case-insensitive), it causes problems when communicating with some API's that don't adhere to this rule.

This PR changes the implementation of `HeaderKey` to store the key in it's original casing. I changed `hashValue` and the `==` operator to use a lowercased version of the keys for comparison, so subscripting a `[HeaderKey : String]` with `content-type` will still match `Content-Type` and also `HeaderKey("content-type") == HeaderKey("Content-Type")` still evaluates to `true`.