### PR TITLE
Add methods to append and remove path components from URIs

### DIFF
--- a/Sources/URI/Model/URI+Modification.swift
+++ b/Sources/URI/Model/URI+Modification.swift
@@ -2,12 +2,14 @@ import Core
 import Foundation
 
 extension URI {
-    /// Returns the components of a given path, ignoring a trailing slash.
-    /// For example:
-    /// 
-    /// `https://github.com/foo/bar` yields `["foo", "bar"]`
-    /// `https://github.com/foo/bar/` yields `["foo", "bar"]`
-    /// `https://github.com/` yields `[]`
+    /**
+        Returns the components of a given path, ignoring a trailing slash.
+        For example:
+ 
+        `https://github.com/foo/bar` yields `["foo", "bar"]`
+        `https://github.com/foo/bar/` yields `["foo", "bar"]`
+        `https://github.com/` yields `[]`
+     */
     private var pathComponents: [String] {
         var components = path.components(separatedBy: "/")
         if components.last == "" {
@@ -16,7 +18,9 @@ extension URI {
         return components
     }
     
-    /// Returns a new URI with the provided path.
+    /**
+        Returns a new URI with the provided path.
+     */
     private func withPath(_ path: String) -> URI {
         return URI(scheme: scheme,
                    userInfo: userInfo,
@@ -27,22 +31,28 @@ extension URI {
                    fragment: fragment)
     }
     
-    /// The last path component of the URL, if there is a path.
-    /// Otherwise returns `nil`.
+    /**
+        The last path component of the URL, if there is a path.
+        Otherwise returns `nil`.
+     */
     var lastPathComponent: String? {
         return pathComponents.last
     }
     
-    /// - returns: a new URI without the path of the receiver.
+    /**
+        - returns: a new URI without the path of the receiver.
+     */
     public func removingPath() -> URI {
         return withPath("")
     }
     
-    /// Constructs a new URI by appending the specified path component.
-    /// - parameters:
-    ///    - pathComponent: The component to add to the path
-    ///    - isDirectory: If true, then the resulting path will have
-    ///                   a trailing '/'
+    /**
+        Constructs a new URI by appending the specified path component.
+        - parameters:
+            - pathComponent: The component to add to the path
+            - isDirectory: If true, then the resulting path will have
+                           a trailing '/'
+     */
     public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool = false) -> URI {
         var components = pathComponents
         components.append(pathComponent)
@@ -52,8 +62,10 @@ extension URI {
         return withPath(components.joined(separator: "/"))
     }
     
-    /// Constructs a new URI by removing the last path component.
-    /// If the path is empty, the result is the same URI.
+    /**
+        Constructs a new URI by removing the last path component.
+        If the path is empty, the result is the same URI.
+     */
     public func deletingLastPathComponent() -> URI {
         if path.isEmpty { return self }
         var components = pathComponents

--- a/Sources/URI/Model/URI+Modification.swift
+++ b/Sources/URI/Model/URI+Modification.swift
@@ -1,0 +1,61 @@
+import Core
+import Foundation
+
+extension URI {
+    /// Returns the components of a given path, ignoring a trailing slash.
+    /// For example:
+    /// 
+    /// `https://github.com/foo/bar` yields `["foo", "bar"]`
+    /// `https://github.com/foo/bar/` yields `["foo", "bar"]`
+    /// `https://github.com/` yields `[]`
+    private var pathComponents: [String] {
+        var components = path.components(separatedBy: "/")
+        if components.last == "" {
+            components.removeLast()
+        }
+        return components
+    }
+    
+    /// Returns a new URI with the provided path, keeping the rest the same.
+    private func withPath(_ path: String) -> URI {
+        return URI(scheme: scheme,
+                   userInfo: userInfo,
+                   host: host,
+                   port: port,
+                   path: path,
+                   query: query,
+                   fragment: fragment)
+    }
+    
+    /// The last path component of the URL, if there is a path
+    var lastPathComponent: String? {
+        return pathComponents.last
+    }
+    
+    /// - returns: a new URI without the path of the receiver.
+    public func removingPath() -> URI {
+        return withPath("")
+    }
+    
+    /// Constructs a new URI by appending the specified path component.
+    /// - parameters:
+    ///    - pathComponent: The component to add to the path
+    ///    - isDirectory: If true, then the resulting path will have
+    ///                   a trailing '/'
+    public func appendingPathComponent(_ pathComponent: String, isDirectory: Bool = false) -> URI {
+        var components = pathComponents
+        components.append(pathComponent)
+        if isDirectory {
+            components.append("")
+        }
+        return withPath(components.joined(separator: "/"))
+    }
+    
+    public func deletingLastPathComponent() -> URI {
+        if path.isEmpty { return self }
+        var components = pathComponents
+        if components.isEmpty { return self }
+        components.removeLast()
+        return withPath(components.joined(separator: "/"))
+    }
+}

--- a/Sources/URI/Model/URI+Modification.swift
+++ b/Sources/URI/Model/URI+Modification.swift
@@ -16,7 +16,7 @@ extension URI {
         return components
     }
     
-    /// Returns a new URI with the provided path, keeping the rest the same.
+    /// Returns a new URI with the provided path.
     private func withPath(_ path: String) -> URI {
         return URI(scheme: scheme,
                    userInfo: userInfo,
@@ -27,7 +27,8 @@ extension URI {
                    fragment: fragment)
     }
     
-    /// The last path component of the URL, if there is a path
+    /// The last path component of the URL, if there is a path.
+    /// Otherwise returns `nil`.
     var lastPathComponent: String? {
         return pathComponents.last
     }
@@ -51,6 +52,8 @@ extension URI {
         return withPath(components.joined(separator: "/"))
     }
     
+    /// Constructs a new URI by removing the last path component.
+    /// If the path is empty, the result is the same URI.
     public func deletingLastPathComponent() -> URI {
         if path.isEmpty { return self }
         var components = pathComponents

--- a/Tests/URITests/URIModificationTests.swift
+++ b/Tests/URITests/URIModificationTests.swift
@@ -40,4 +40,26 @@ class URIModificationTests: XCTestCase {
         uri = uri.deletingLastPathComponent()
         XCTAssertEqual(uri.path, "")
     }
+    
+    func testRemovingPath() {
+        var uri = try! URI("https://vapor.github.io/documentation/foo/bar/baz")
+        uri = uri.removingPath()
+        XCTAssertEqual(uri.path, "")
+        uri = uri.removingPath()
+        XCTAssertEqual(uri.path, "")
+    }
+    
+    func testLastPathComponent() {
+        var uri = try! URI("https://vapor.github.io/documentation/foo/bar/baz")
+        XCTAssertEqual(uri.lastPathComponent, "baz")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.lastPathComponent, "bar")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.lastPathComponent, "foo")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.lastPathComponent, "documentation")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.lastPathComponent, nil)
+        
+    }
 }

--- a/Tests/URITests/URIModificationTests.swift
+++ b/Tests/URITests/URIModificationTests.swift
@@ -1,0 +1,43 @@
+//
+//  URIModificationTests.swift
+//  Engine
+//
+//  Created by Harlan Haskins on 9/25/16.
+//
+//
+
+import XCTest
+@testable import URI
+
+class URIModificationTests: XCTestCase {
+    func testAppendPathComponent() {
+        var uri = try! URI("https://vapor.github.io/documentation/")
+        XCTAssertEqual(uri.path, "/documentation/")
+        uri = uri.appendingPathComponent("foo")
+        XCTAssertEqual(uri.path, "/documentation/foo")
+        uri = uri.appendingPathComponent("bar")
+        XCTAssertEqual(uri.path, "/documentation/foo/bar")
+        uri = uri.appendingPathComponent("baz")
+        XCTAssertEqual(uri.path, "/documentation/foo/bar/baz")
+        uri = uri.appendingPathComponent("fizz", isDirectory: true)
+        XCTAssertEqual(uri.path, "/documentation/foo/bar/baz/fizz/")
+        uri = uri.appendingPathComponent("", isDirectory: true)
+        XCTAssertEqual(uri.path, "/documentation/foo/bar/baz/fizz//")
+        uri = uri.appendingPathComponent("", isDirectory: false)
+        XCTAssertEqual(uri.path, "/documentation/foo/bar/baz/fizz//")
+    }
+    func testRemovePathComponent() {
+        var uri = try! URI("https://vapor.github.io/documentation/foo/bar/baz")
+        XCTAssertEqual(uri.path, "/documentation/foo/bar/baz")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.path, "/documentation/foo/bar")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.path, "/documentation/foo")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.path, "/documentation")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.path, "")
+        uri = uri.deletingLastPathComponent()
+        XCTAssertEqual(uri.path, "")
+    }
+}


### PR DESCRIPTION
Adds `appendingPathComponent`, `deletingLastPathComponent`, and `removingPath` to the public API for `URI`.