### PR TITLE
Added a final check to ensure the socket is closed

### DIFF
--- a/Sources/HTTP/Models/Client/HTTP+Client.swift
+++ b/Sources/HTTP/Models/Client/HTTP+Client.swift
@@ -79,7 +79,7 @@ public final class Client<
     }
     
     deinit {
-        //try? stream.close()
+        try? stream.close()
     }
 
     public func respond(to request: Request) throws -> Response {

--- a/Sources/HTTP/Models/Client/HTTP+Client.swift
+++ b/Sources/HTTP/Models/Client/HTTP+Client.swift
@@ -79,7 +79,7 @@ public final class Client<
     }
     
     deinit {
-        try? stream.close()
+        //try? stream.close()
     }
 
     public func respond(to request: Request) throws -> Response {

--- a/Sources/HTTP/Models/Client/HTTP+Client.swift
+++ b/Sources/HTTP/Models/Client/HTTP+Client.swift
@@ -77,6 +77,10 @@ public final class Client<
         // add middleware
         responder = self.middleware.chain(to: handler)
     }
+    
+    deinit {
+        try? stream.close()
+    }
 
     public func respond(to request: Request) throws -> Response {
         try assertValid(request)

--- a/Tests/HTTPTests/HTTPBodyTests.swift
+++ b/Tests/HTTPTests/HTTPBodyTests.swift
@@ -6,6 +6,7 @@ class HTTPBodyTests: XCTestCase {
     static var allTests = [
         ("testBufferParse", testBufferParse),
         ("testChunkedParse", testChunkedParse),
+        ("testClientStreamUsage", testClientStreamUsage),
     ]
 
     func testBufferParse() throws {

--- a/Tests/HTTPTests/HTTPBodyTests.swift
+++ b/Tests/HTTPTests/HTTPBodyTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import HTTP
 import Transport
+import libc
 
 class HTTPBodyTests: XCTestCase {
     static var allTests = [

--- a/Tests/HTTPTests/HTTPBodyTests.swift
+++ b/Tests/HTTPTests/HTTPBodyTests.swift
@@ -72,7 +72,7 @@ class HTTPBodyTests: XCTestCase {
         usleep(useconds_t(microseconds))
 
         do {
-            for _ in 0..<16384 {
+            for _ in 0..<8192 {
                 let res = try HTTP.Client<TCPClientStream, Serializer<Request>, Parser<Response>>.get("http://0.0.0.0:8637/")
                 XCTAssertEqual(res.body.bytes ?? [], "Hello".bytes)
             }


### PR DESCRIPTION
@tannernelson and I were discussing about servers going down because of `Server error: accept(Socket failed with code 24 ("Too many open files") [acceptFailed] "Unknown error")` caused by `Client` not closing the socket.