### PR TITLE
peerAddress is now reported correctly for TLS server sockets

### DIFF
--- a/Sources/Transport/Streams/Socks+Stream.swift
+++ b/Sources/Transport/Streams/Socks+Stream.swift
@@ -143,7 +143,7 @@ extension TLS.Socket: Stream {
     }
 
     public var peerAddress: String {
-        return socket.peerAddress
+        return currSocket?.peerAddress ?? socket.peerAddress
     }
 }
 


### PR DESCRIPTION
For connections created by calling accept() on a server TLS socket, the
peerAddress would always be reported as 0.0.0.0, because the actual
socket is referenced by currSocket.