### PR TITLE
SMTP date formatter now works in non-US locales

### DIFF
--- a/Sources/SMTP/Utility/NSDate+SMTP.swift
+++ b/Sources/SMTP/Utility/NSDate+SMTP.swift
@@ -49,6 +49,7 @@ extension DateFormatter {
     */
     static func makeSMTPFormatter() -> DateFormatter {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en-US")
         formatter.dateFormat = "EEE, d MMM yyyy HH:mm:ss ZZZ"
         return formatter
     }

--- a/Tests/SMTPTests/SMTPDateTests.swift
+++ b/Tests/SMTPTests/SMTPDateTests.swift
@@ -21,10 +21,14 @@ class SMTPDateTests: XCTestCase {
     ]
 
     func testSMTPDate() {
-        let date = Date(timeIntervalSince1970: 0)
+        // Create date from components to ensure it's January 1st 1970 00:00:00 in the _local_ calendar (because that's what this test expects)
+        var dateComponents = DateComponents()
+        dateComponents.year = 1970
+        let date = Calendar.current.date(from: dateComponents)!
+
         let smtpFormatted = date.smtpFormatted
-        XCTAssert(smtpFormatted.hasPrefix("Wed, 31 Dec 1969 "))
-        let suffix = smtpFormatted.components(separatedBy: "Wed, 31 Dec 1969 ").last ?? ""
+        XCTAssert(smtpFormatted.hasPrefix("Thu, 1 Jan 1970 00:00:00 "))
+        let suffix = smtpFormatted.components(separatedBy: "Thu, 1 Jan 1970 ").last ?? ""
         let timeComps = suffix.components(separatedBy: " ")
         XCTAssert(timeComps.count == 2)
 


### PR DESCRIPTION
- SMTPDateFormatter is now always initialized with an en-US locale (which is what RFC 2822 implicitly expects).
- Fixed a test which used to fail in some timezones, because 1970-01-01 00:00 UTC is 1969-12-31 in the US