### PR TITLE
Close stream on `StreamError`

### DIFF
--- a/Sources/HTTP/Models/Server/HTTP+Server.swift
+++ b/Sources/HTTP/Models/Server/HTTP+Server.swift
@@ -146,6 +146,12 @@ public final class Server<
             } catch ParserError.streamEmpty {
                 self?.streams.remove(stream)
                 try? stream.close()
+            } catch is StreamError {
+                // if there's a problem with the stream, there's no point in keeping it open.
+                // reporting the error is not necessary here; there are various legitimate
+                // reasons for socket connections to be broken.
+                self?.streams.remove(stream)
+                try? stream.close()
             } catch {
                 errors(.respond(error))
             }


### PR DESCRIPTION
If there's a problem with the stream, there's no point in keeping it open.