### PR TITLE
Re-added error logging if a `StreamError` occurs

### DIFF
--- a/Sources/HTTP/Models/Server/HTTP+Server.swift
+++ b/Sources/HTTP/Models/Server/HTTP+Server.swift
@@ -148,10 +148,10 @@ public final class Server<
                 try? stream.close()
             } catch let error where error is StreamError {
                 // if there's a problem with the stream, there's no point in keeping it open.
-                // reporting the error is not necessary here; there are various legitimate
-                // reasons for socket connections to be broken.
                 self?.streams.remove(stream)
                 try? stream.close()
+                // reporting the error is not strictly necessary here (there are  legitimate
+                // reasons for socket connections to be broken), but helpful for debugging.
                 errors(.respond(error))
             } catch {
                 errors(.respond(error))

--- a/Sources/HTTP/Models/Server/HTTP+Server.swift
+++ b/Sources/HTTP/Models/Server/HTTP+Server.swift
@@ -146,12 +146,13 @@ public final class Server<
             } catch ParserError.streamEmpty {
                 self?.streams.remove(stream)
                 try? stream.close()
-            } catch is StreamError {
+            } catch let error where error is StreamError {
                 // if there's a problem with the stream, there's no point in keeping it open.
                 // reporting the error is not necessary here; there are various legitimate
                 // reasons for socket connections to be broken.
                 self?.streams.remove(stream)
                 try? stream.close()
+                errors(.respond(error))
             } catch {
                 errors(.respond(error))
             }


### PR DESCRIPTION
Error logging for `StreamError` is still required for debugging purposes (@LoganWright I wrongly omitted that in the previous PR).