### PR TITLE
websocket nonblocking fix

### DIFF
--- a/Sources/Transport/Streams/Stream.swift
+++ b/Sources/Transport/Streams/Stream.swift
@@ -31,11 +31,11 @@ public protocol Stream: class, Watchable {
 
 extension Stream {
     public func startWatching(on queue: DispatchQueue, handler: @escaping () -> ()) throws {
-        throw StreamError.unsupported
+        // do nothing
     }
     
     public func stopWatching() throws {
-        throw StreamError.unsupported
+        // do nothing
     }
 }
 

--- a/Sources/WebSockets/Serialization/FrameDeserializer.swift
+++ b/Sources/WebSockets/Serialization/FrameDeserializer.swift
@@ -13,6 +13,9 @@ public final class FrameParser {
     }
 
     public func acceptFrame() throws -> WebSocket.Frame {
+        // convert the stream back to blocking
+        try stream.stopWatching()
+
         let (fin, rsv1, rsv2, rsv3, opCode) = try extractByteZero()
         let (isMasked, payloadLengthInfo) = try extractByteOne()
 

--- a/Tests/TransportTests/StreamBufferTests.swift
+++ b/Tests/TransportTests/StreamBufferTests.swift
@@ -54,18 +54,26 @@ class StreamBufferTests: XCTestCase {
     }
 
     func testStreamBufferFlushes() throws {
-        try streamBuffer.send(1)
-        try streamBuffer.flush()
-        XCTAssert(testStream.flushedCount == 1, "should have flushed")
+        do {
+            try streamBuffer.send(1)
+            try streamBuffer.flush()
+            XCTAssert(testStream.flushedCount == 1, "should have flushed")
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
     }
 
     func testStreamBufferMisc() throws {
-        try streamBuffer.close()
-        XCTAssert(testStream.closed, "stream buffer should close underlying stream")
-        XCTAssert(streamBuffer.closed, "stream buffer should reflect closed status of underlying stream")
+        do {
+            try streamBuffer.close()
+            XCTAssert(testStream.closed, "stream buffer should close underlying stream")
+            XCTAssert(streamBuffer.closed, "stream buffer should reflect closed status of underlying stream")
 
-        try streamBuffer.setTimeout(42)
-        XCTAssert(testStream.timeout == 42, "stream buffer should set underlying timeout")
+            try streamBuffer.setTimeout(42)
+            XCTAssert(testStream.timeout == 42, "stream buffer should set underlying timeout")
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
     }
 }
 


### PR DESCRIPTION
Converts a stream back to blocking before parsing websocket frames.

Fixes https://github.com/vapor/vapor/issues/738.