### PR TITLE
Add support for client-specified headers

### DIFF
--- a/Sources/HTTP/Models/Server/HTTP+Server.swift
+++ b/Sources/HTTP/Models/Server/HTTP+Server.swift
@@ -152,7 +152,7 @@ public final class Server<
                 try? stream.close()
                 // reporting the error is not strictly necessary here (there are  legitimate
                 // reasons for socket connections to be broken), but helpful for debugging.
-                errors(.respond(error))
+                // errors(.respond(error))
             } catch {
                 errors(.respond(error))
             }

--- a/Sources/HTTP/Models/Server/HTTP+Server.swift
+++ b/Sources/HTTP/Models/Server/HTTP+Server.swift
@@ -152,7 +152,7 @@ public final class Server<
                 try? stream.close()
                 // reporting the error is not strictly necessary here (there are  legitimate
                 // reasons for socket connections to be broken), but helpful for debugging.
-                // errors(.respond(error))
+                errors(.respond(error))
             } catch {
                 errors(.respond(error))
             }

--- a/Sources/WebSockets/Client/WebSocket+Client.swift
+++ b/Sources/WebSockets/Client/WebSocket+Client.swift
@@ -4,10 +4,6 @@ import Transport
 import URI
 import HTTP
 
-public enum ResponseError: Swift.Error {
-    case status(Status)
-}
-
 extension WebSocket {
     public static func background(to uri: String, using client: ClientProtocol.Type = Client<TCPClientStream, Serializer<Request>, Parser<Response>>.self, protocols: [String]? = nil, headers: [HeaderKey: String]? = nil, onConnect: @escaping (WebSocket) throws -> Void) throws {
         let uri = try URI(uri)
@@ -54,7 +50,7 @@ extension WebSocket {
         )
         let response = try client.respond(to: request)
 
-        guard response.status == .switchingProtocols else { throw ResponseError.status(response.status) }
+        guard response.status == .switchingProtocols else { throw FormatError.invalidOrUnsupportedStatus(response.status) }
         // Don't need to check version in server response
         guard response.headers.connection?.lowercased() == "upgrade" else { throw FormatError.missingConnectionHeader }
         guard response.headers.upgrade?.lowercased() == "websocket" else { throw FormatError.missingUpgradeHeader }

--- a/Sources/WebSockets/Client/WebSocket+Client.swift
+++ b/Sources/WebSockets/Client/WebSocket+Client.swift
@@ -58,7 +58,6 @@ extension WebSocket {
         // Don't need to check version in server response
         guard response.headers.connection?.lowercased() == "upgrade" else { throw FormatError.missingConnectionHeader }
         guard response.headers.upgrade?.lowercased() == "websocket" else { throw FormatError.missingUpgradeHeader }
-        guard case .switchingProtocols = response.status else { throw FormatError.invalidOrUnsupportedStatus }
         guard let accept = response.headers.secWebSocketAccept else { throw FormatError.missingSecAcceptHeader }
         let expected = try WebSocket.exchange(requestKey: requestKey)
         guard accept == expected else { throw FormatError.invalidSecAcceptHeader }

--- a/Sources/WebSockets/WebSocketFormatErrors.swift
+++ b/Sources/WebSockets/WebSocketFormatErrors.swift
@@ -12,3 +12,29 @@ extension WebSocket {
         case invalidOrUnsupportedStatus(Status)
     }
 }
+
+extension WebSocket.FormatError: Equatable {
+    public static func ==(lhs: WebSocket.FormatError, rhs: WebSocket.FormatError) -> Bool {
+        switch (lhs, rhs) {
+        case (.missingSecKeyHeader, .missingSecKeyHeader):
+            return true
+        case (.missingSecAcceptHeader, .missingSecAcceptHeader):
+            return true
+        case (.invalidSecAcceptHeader, .invalidSecAcceptHeader):
+            return true
+        case (.missingUpgradeHeader, .missingUpgradeHeader):
+            return true
+        case (.missingConnectionHeader, .missingConnectionHeader):
+            return true
+        case (.invalidURI, .invalidURI):
+            return true
+        case (.invalidOrUnsupportedVersion, .invalidOrUnsupportedVersion):
+            return true
+        case (.invalidOrUnsupportedStatus(let lhsStatus), .invalidOrUnsupportedStatus(let rhsStatus)):
+            return lhsStatus == rhsStatus
+        default:
+            return false
+        }
+    }
+}
+

--- a/Sources/WebSockets/WebSocketFormatErrors.swift
+++ b/Sources/WebSockets/WebSocketFormatErrors.swift
@@ -1,3 +1,5 @@
+import HTTP
+
 extension WebSocket {
     public enum FormatError: Swift.Error {
         case missingSecKeyHeader
@@ -7,6 +9,6 @@ extension WebSocket {
         case missingConnectionHeader
         case invalidURI
         case invalidOrUnsupportedVersion
-        case invalidOrUnsupportedStatus
+        case invalidOrUnsupportedStatus(Status)
     }
 }

--- a/Tests/HTTPTests/HTTPBodyTests.swift
+++ b/Tests/HTTPTests/HTTPBodyTests.swift
@@ -86,7 +86,8 @@ class HTTPBodyTests: XCTestCase {
         // WARNING: `server` will keep running in the background since there is no way to stop it. Its socket will continue to exist and the associated port will be in use until the xctest process exits.
     }
 
-/*    func testClientStreamUsageAsync() throws {
+    func testClientStreamUsageAsync() throws {
+#if os(Linux)
         let server = try HTTP.Server<TCPServerStream, Parser<Request>, Serializer<Response>>(host: "0.0.0.0", port: 0, securityLayer: .none)
         let assignedPort = try server.server.stream.localAddress().port
 
@@ -112,7 +113,8 @@ class HTTPBodyTests: XCTestCase {
         } catch {
             XCTFail("\(error)")
         }
-    } */
+#endif
+    } 
     
     
 //    /**

--- a/Tests/HTTPTests/HTTPBodyTests.swift
+++ b/Tests/HTTPTests/HTTPBodyTests.swift
@@ -86,7 +86,7 @@ class HTTPBodyTests: XCTestCase {
         // WARNING: `server` will keep running in the background since there is no way to stop it. Its socket will continue to exist and the associated port will be in use until the xctest process exits.
     }
 
-    func testClientStreamUsageAsync() throws {
+/*    func testClientStreamUsageAsync() throws {
         let server = try HTTP.Server<TCPServerStream, Parser<Request>, Serializer<Response>>(host: "0.0.0.0", port: 0, securityLayer: .none)
         let assignedPort = try server.server.stream.localAddress().port
 
@@ -112,7 +112,7 @@ class HTTPBodyTests: XCTestCase {
         } catch {
             XCTFail("\(error)")
         }
-    }
+    } */
     
     
 //    /**

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -29,6 +29,7 @@ XCTMain([
     // WebSocketsTestSuite
     testCase(WebSocketSerializationTests.allTests),
     testCase(WebSocketKeyTests.allTests),
+    testCase(WebSocketConnectTests.allTests),
 
     // SMTPTestSuite
     testCase(EmailAddressTests.allTests),

--- a/Tests/TransportTests/SockStreamTests.swift
+++ b/Tests/TransportTests/SockStreamTests.swift
@@ -65,7 +65,8 @@ class SockStreamTests: XCTestCase {
         } catch {}
     }
 
-/*    func testTCPServerStreamNonblocking() throws {
+    func testTCPServerStreamNonblocking() throws {
+#if os(Linux)
         let host = "0.0.0.0"
         let data = "Hello, World!".bytes
         let backgroundQueue = DispatchQueue.global(qos: .background)
@@ -113,7 +114,9 @@ class SockStreamTests: XCTestCase {
             XCTFail("Test timed out waiting")
             return
         }
-    } */
+#endif
+    } 
+
 
     func testTCPServer() throws {
         let serverStream = try TCPServerStream(host: "0.0.0.0", port: 2653)

--- a/Tests/TransportTests/SockStreamTests.swift
+++ b/Tests/TransportTests/SockStreamTests.swift
@@ -65,7 +65,7 @@ class SockStreamTests: XCTestCase {
         } catch {}
     }
 
-    func testTCPServerStreamNonblocking() throws {
+/*    func testTCPServerStreamNonblocking() throws {
         let host = "0.0.0.0"
         let data = "Hello, World!".bytes
         let backgroundQueue = DispatchQueue.global(qos: .background)
@@ -113,7 +113,7 @@ class SockStreamTests: XCTestCase {
             XCTFail("Test timed out waiting")
             return
         }
-    }
+    } */
 
     func testTCPServer() throws {
         let serverStream = try TCPServerStream(host: "0.0.0.0", port: 2653)
@@ -217,7 +217,7 @@ class TLSStreamTests: XCTestCase {
         do {
             let clientStream = try TCPClientStream(host: "api.spotify.com", port: 443, securityLayer: .tls(config)).connect()
             let uri = "/v1/search?type=artist&q=hannah%20diamond"
-            try clientStream.send("GET \(uri) HTTP/1.1\r\nHost: api.spotify.com\r\n\r\n".bytes)
+            try clientStream.send("GET \(uri) HTTP/1.1\r\nHost: api.spotify.com\r\nAccept: */*\r\n\r\n".bytes)
             let response = try clientStream.receive(max: 2048).string
 
             XCTAssert(response.contains("spotify:artist:3sXErEOw7EmO6Sj7EgjHdU"))

--- a/Tests/WebSocketsTests/WebSocketParsingTests.swift
+++ b/Tests/WebSocketsTests/WebSocketParsingTests.swift
@@ -336,12 +336,12 @@ class WebSocketKeyTests: XCTestCase {
 
 class WebSocketConnectTests : XCTestCase {
 
-    static var allTests: [(String, (WebSocketKeyTests) -> () throws -> Void)] {
+    static var allTests: [(String, (WebSocketConnectTests) -> () throws -> Void)] {
         return [
             ("testBackgroundConnect", testBackgroundConnect)
         ]
     }
-
+ 
    func testBackgroundConnect() throws {
       
 	let headers: [HeaderKey: String] = ["Authorized": "Bearer exampleBearer"]

--- a/Tests/WebSocketsTests/WebSocketParsingTests.swift
+++ b/Tests/WebSocketsTests/WebSocketParsingTests.swift
@@ -334,6 +334,21 @@ class WebSocketKeyTests: XCTestCase {
     }
 }
 
+class WebSocketConnectTests : XCTestCase {
+
+   func testBackgroundConnect() throws {
+      
+	let headers: [HeaderKey: String] = ["Authorized": "Bearer exampleBearer"]
+	do {
+	   let client = try WebSocket.background(to:"ws:127.0.0.1", headers: headers) { (websocket: WebSocket) throws -> Void in
+                    XCTAssert(false, "No server, so this should fail to connect")
+		    }
+	} catch {
+	    XCTAssert(true, "Expected to throw an error when there is no server available")
+	}
+    }
+}
+
 final class TestStream: Transport.Stream {
     
     var peerAddress: String = "1.2.3.4:5678"

--- a/Tests/WebSocketsTests/WebSocketParsingTests.swift
+++ b/Tests/WebSocketsTests/WebSocketParsingTests.swift
@@ -336,6 +336,12 @@ class WebSocketKeyTests: XCTestCase {
 
 class WebSocketConnectTests : XCTestCase {
 
+    static var allTests: [(String, (WebSocketKeyTests) -> () throws -> Void)] {
+        return [
+            ("testBackgroundConnect", testBackgroundConnect)
+        ]
+    }
+
    func testBackgroundConnect() throws {
       
 	let headers: [HeaderKey: String] = ["Authorized": "Bearer exampleBearer"]


### PR DESCRIPTION
These changes allow the WebSocket client to include client-specified headers.  This allows using VaporJWT for authorization of web socket clients