### PR TITLE
Allow the server to send an error (don’t always set the error length …

### DIFF
--- a/Sources/WebSockets/Model/WebSocket.swift
+++ b/Sources/WebSockets/Model/WebSocket.swift
@@ -115,13 +115,10 @@ extension WebSocket {
             do {
                 let frame = try parser.acceptFrame()
                 try received(frame)
-            } catch { 
-                // TODO: Throw for application to catch
-                // or pass logger
-                // Log.error("WebSocket Failed w/ error: \(error)")
-		// It is wrong to close the socket on this error, so the following is commented out
-		// until the final answer about how to handle the exception is resolved
-                // try completeCloseHandshake(statusCode: nil, reason: nil, cleanly: false)
+            } catch {
+                if
+                    case let StreamError.receive(_, recError as SocksError) = error, recError.number == 35  { continue }
+                try completeCloseHandshake(statusCode: nil, reason: nil, cleanly: false)
             }
         }
     }

--- a/Sources/WebSockets/Model/WebSocket.swift
+++ b/Sources/WebSockets/Model/WebSocket.swift
@@ -1,3 +1,4 @@
+import struct Core.Bytes
 import Transport
 import Socks
 import SocksCore

--- a/Sources/WebSockets/Model/WebSocket.swift
+++ b/Sources/WebSockets/Model/WebSocket.swift
@@ -1,5 +1,6 @@
-import struct Core.Bytes
-import protocol Transport.Stream
+import Transport
+import Socks
+import SocksCore
 
 public final class WebSocket {
 


### PR DESCRIPTION
…to zero)

Parse properly the reason string on the receiver of the error