### PR TITLE
Fixes URI parsing when bytes contains authority and existingHost is non nil.

### DIFF
--- a/Sources/URI/Parser/Parser+Components.swift
+++ b/Sources/URI/Parser/Parser+Components.swift
@@ -39,8 +39,7 @@ extension URIParser {
         authority   = [ userinfo "@" ] host [ ":" port ]
     */
     internal func parseAuthority() throws -> [Byte]? {
-        if let existingHost = existingHost { return existingHost.array }
-        guard try checkLeadingBuffer(matches: .forwardSlash, .forwardSlash) else { return nil }
+        guard try checkLeadingBuffer(matches: .forwardSlash, .forwardSlash) else { return existingHost?.array }
         try discardNext(2) // discard '//'
         return try collect(until: .forwardSlash, .questionMark, .numberSign)
     }

--- a/Tests/URITests/URISerializationTests.swift
+++ b/Tests/URITests/URISerializationTests.swift
@@ -146,6 +146,17 @@ class URISerializationTests: XCTestCase {
                      path: "",
                      query: "fred",
                      fragment: nil)
+
+        try makeSure(input: "http://pokeapi.co/api/v2",
+                     existingHost: "existing-pokeapi.co",
+                     equalsScheme: "http",
+                     host: "pokeapi.co",
+                     username: "",
+                     pass: "",
+                     port: 80,
+                     path: "/api/v2",
+                     query: nil,
+                     fragment: nil)
     }
 
     func testPercentEncodedInsideParsing() throws {
@@ -258,6 +269,7 @@ class URISerializationTests: XCTestCase {
     }
 
     private func makeSure(input: String,
+                          existingHost: String? = nil,
                           equalsScheme scheme: String,
                           host: String,
                           username: String,
@@ -267,7 +279,7 @@ class URISerializationTests: XCTestCase {
                           query: String?,
                           fragment: String?) throws {
 
-        let uri = try URIParser.parse(bytes: input.utf8.array)
+        let uri = try URIParser.parse(bytes: input.utf8.array, existingHost: existingHost)
         XCTAssert(uri.scheme == scheme, "\(input) -- expected scheme: \(scheme) got: \(uri.scheme)")
         XCTAssert(uri.host == host, "\(input) -- expected host: \(host) got: \(uri.host)")
         let testUsername = uri.userInfo?.username ?? ""


### PR DESCRIPTION
An issue surfaced when parsing the URI of a proxied HTTP request.

### Regular Query

```
> nc -l 4242

[...]

> curl http://localhost:4242/api/v2/

GET /api/v2/ HTTP/1.1
Host: localhost:4242
User-Agent: curl/7.51.0
Accept: */*

```

### Proxied Query

```
> nc -l 4242

[...]

> http_proxy=http://localhost:4242 curl http://pokeapi.co/api/v2/

GET http://pokeapi.co/api/v2/ HTTP/1.1
Host: pokeapi.co
User-Agent: curl/7.51.0
Accept: */*
Proxy-Connection: Keep-Alive
```

The presence of an `existingHost` isn't enough to determine if the buffer is free of an authority (as seen in the proxied query example above). This change prevents `parseAuthority` from bailing out if an `existingHost` is present by prioritizing the check on the buffer first.

In this instance, a decision has to be made whether the returned authority should come from `existingHost` or from the buffer. Currently the authority from the buffer will be returned. The added test case also asserts that the returned authority originates from the bytes array rather than the optional `existingHost` property.
