### PR TITLE
Support for SameSite cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Packages
 .DS_Store
 *.xcodeproj
 Package.pins
+DerivedData/

--- a/Sources/Cookies/Cookie+Parse.swift
+++ b/Sources/Cookies/Cookie+Parse.swift
@@ -25,6 +25,7 @@ extension Cookie {
         var path: String?
         var secure = false
         var httpOnly = false
+        var sameSite: Cookie.SameSite?
 
 
         // cookies are sent separated by semicolons
@@ -56,6 +57,12 @@ extension Cookie {
                 secure = true
             case "max-age":
                 maxAge = Int(val) ?? 0
+            case "samesite":
+                if val.lowercased() == "lax" {
+                    sameSite = .lax
+                } else {
+                    sameSite = .strict
+                }
             default:
                 name = key
                 value = val
@@ -77,7 +84,8 @@ extension Cookie {
             domain: domain,
             path: path,
             secure: secure,
-            httpOnly: httpOnly
+            httpOnly: httpOnly,
+            sameSite: sameSite
         )
     }
 

--- a/Sources/Cookies/Cookie+Serialize.swift
+++ b/Sources/Cookies/Cookie+Serialize.swift
@@ -31,6 +31,16 @@ extension Cookie {
             serialized += "; HttpOnly"
         }
         
+        if let sameSite = sameSite {
+            serialized += "; SameSite"
+            switch sameSite {
+            case .lax:
+                serialized += "=Lax"
+            default:
+                serialized += "=Strict"
+            }
+        }
+        
         return serialized
     }
 }

--- a/Sources/Cookies/Cookie.swift
+++ b/Sources/Cookies/Cookie.swift
@@ -14,6 +14,12 @@ public struct Cookie {
     public var path: String?
     public var secure: Bool
     public var httpOnly: Bool
+    public var sameSite: SameSite?
+    
+    public enum SameSite {
+        case strict
+        case lax
+    }
 
     public init(
         name: String,
@@ -23,7 +29,8 @@ public struct Cookie {
         domain: String? = nil,
         path: String? = "/",
         secure: Bool = false,
-        httpOnly: Bool = false
+        httpOnly: Bool = false,
+        sameSite: SameSite? = nil
     ) {
         self.name = name
         self.value = value
@@ -33,6 +40,7 @@ public struct Cookie {
         self.path = path
         self.secure = secure
         self.httpOnly = httpOnly
+        self.sameSite = sameSite
     }
 }
 

--- a/Tests/CookiesTests/CookieTests.swift
+++ b/Tests/CookiesTests/CookieTests.swift
@@ -14,6 +14,9 @@ class CookieTests: XCTestCase {
         ("testInit_setsSecureCorrectly", testInit_setsSecureCorrectly),
         ("testInit_defaultsToNonHTTPOnly", testInit_defaultsToNonHTTPOnly),
         ("testInit_setsHTTPOnlyCorrectly", testInit_setsHTTPOnlyCorrectly),
+        ("testInit_defaultToNoSameSite", testInit_defaultToNoSameSite),
+        ("testInit_setsSameSiteCorrectlyStrict", testInit_setsSameSiteCorrectlyStrict),
+        ("testInit_setsSameSiteCorrectlyLax", testInit_setsSameSiteCorrectlyLax),
         ("testHashValue_usesNamesHash", testHashValue_usesNamesHash),
         ("testEquality_reliesSolelyOnName", testEquality_reliesSolelyOnName),
         ("testSerialize_producesExpectedOutput", testSerialize_producesExpectedOutput)
@@ -68,6 +71,21 @@ class CookieTests: XCTestCase {
         let subject = Cookie(name: "Foo", value: "Bar", httpOnly: true)
         XCTAssertTrue(subject.httpOnly)
     }
+    
+    func testInit_defaultToNoSameSite() {
+        let subject = Cookie(name: "Foo", value: "Bar")
+        XCTAssertNil(subject.sameSite)
+    }
+    
+    func testInit_setsSameSiteCorrectlyStrict() {
+        let subject = Cookie(name: "Foo", value: "Bar", sameSite: .strict)
+        XCTAssertEqual(subject.sameSite, Cookie.SameSite.strict)
+    }
+    
+    func testInit_setsSameSiteCorrectlyLax() {
+        let subject = Cookie(name: "Foo", value: "Bar", sameSite: .lax)
+        XCTAssertEqual(subject.sameSite, Cookie.SameSite.lax)
+    }
 
     func testHashValue_usesNamesHash() {
         let subject = Cookie(name: "Foo", value: "Bar")
@@ -98,5 +116,9 @@ class CookieTests: XCTestCase {
         XCTAssertEqual(subject.serialize(), "Foo=Bar; Expires=Wed, 20 Jul 2016 09:00:15 GMT; Max-Age=600; Domain=vapor.qutheory.io; Path=/bar/food/yum; Secure")
         subject.httpOnly = true
         XCTAssertEqual(subject.serialize(), "Foo=Bar; Expires=Wed, 20 Jul 2016 09:00:15 GMT; Max-Age=600; Domain=vapor.qutheory.io; Path=/bar/food/yum; Secure; HttpOnly")
+        subject.sameSite = .lax
+        XCTAssertEqual(subject.serialize(), "Foo=Bar; Expires=Wed, 20 Jul 2016 09:00:15 GMT; Max-Age=600; Domain=vapor.qutheory.io; Path=/bar/food/yum; Secure; HttpOnly; SameSite=Lax")
+        subject.sameSite = .strict
+        XCTAssertEqual(subject.serialize(), "Foo=Bar; Expires=Wed, 20 Jul 2016 09:00:15 GMT; Max-Age=600; Domain=vapor.qutheory.io; Path=/bar/food/yum; Secure; HttpOnly; SameSite=Strict")
     }
 }

--- a/Tests/CookiesTests/ParsingTests.swift
+++ b/Tests/CookiesTests/ParsingTests.swift
@@ -9,6 +9,9 @@ class ParsingTests: XCTestCase {
         ("testExpires", testExpires),
         ("testHTTPOnly", testHTTPOnly),
         ("testSecure", testSecure),
+        ("testSameSiteDefault", testSameSiteDefault),
+        ("testSameSiteLax", testSameSiteLax),
+        ("testSameSiteStrict", testSameSiteStrict),
         ("testMaxAge", testMaxAge),
         ("testMaxAgeInvalid", testMaxAgeInvalid),
         ("testInvalid", testInvalid),
@@ -44,6 +47,21 @@ class ParsingTests: XCTestCase {
     func testSecure() throws {
         let cookie = try Cookie("cookie=1337; Secure")
         XCTAssertEqual(cookie.secure, true)
+    }
+    
+    func testSameSiteDefault() throws {
+        let cookie = try Cookie("cookie=1337; SameSite")
+        XCTAssertEqual(cookie.sameSite, Cookie.SameSite.strict)
+    }
+    
+    func testSameSiteLax() throws {
+        let cookie = try Cookie("cookie=1337; SameSite=Lax")
+        XCTAssertEqual(cookie.sameSite, Cookie.SameSite.lax)
+    }
+    
+    func testSameSiteStrict() throws {
+        let cookie = try Cookie("cookie=1337; SameSite=Strict")
+        XCTAssertEqual(cookie.sameSite, Cookie.SameSite.strict)
     }
 
     func testMaxAge() throws {


### PR DESCRIPTION
This PR adds support for [Same Site Cookies](https://tools.ietf.org/html/draft-west-first-party-cookies-07) which is a security feature to help mitigate CSRF and similar attacks. 

I'm also considering adding support for [Cookie Prefixes](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00) if you think it will be useful? Would probably require a bit more logic to ensure that the cookies are valid if trying to set the prefixes, but nothing a few tests can't handle!