### PR TITLE
Conformance is done at declaration site for HeaderKey. 

### DIFF
--- a/Sources/HTTP/Models/Client/HTTP+Client.swift
+++ b/Sources/HTTP/Models/Client/HTTP+Client.swift
@@ -64,7 +64,7 @@ public final class BasicClient<
             throw ClientError.unableToConnect
         }
 
-        ///  client MUST send a Host header field in all HTTP/1.1 request
+        /// client MUST send a Host header field in all HTTP/1.1 request
         /// messages.  If the target URI includes an authority component, then a
         /// client MUST send a field-value for Host that is identical to that
         /// authority component, excluding any userinfo subcomponent and its "@"

--- a/Sources/HTTP/Models/Headers/Headers.swift
+++ b/Sources/HTTP/Models/Headers/Headers.swift
@@ -38,9 +38,7 @@ extension HeaderKey: Hashable {
     public var hashValue: Int {
         return key.lowercased().hashValue
     }
-}
 
-extension HeaderKey: Equatable {
     static public func ==(lhs: HeaderKey, rhs: HeaderKey) -> Bool {
         return lhs.key.lowercased() == rhs.key.lowercased()
     }

--- a/Sources/HTTP/Models/Headers/Headers.swift
+++ b/Sources/HTTP/Models/Headers/Headers.swift
@@ -21,24 +21,28 @@ extension KeyAccessible where Key == HeaderKey, Value == String {
 
 // TODO: => Core ^
 
-public struct HeaderKey: Hashable, CustomStringConvertible {
+public struct HeaderKey {
     public let key: String
     public init(_ key: String) {
         self.key = key
     }
 }
 
-extension HeaderKey {
+extension HeaderKey: CustomDebugStringConvertible {
     public var description: String {
         return key
     }
 }
 
-extension HeaderKey: Equatable {}
-
-extension HeaderKey {
+extension HeaderKey: Hashable {
     public var hashValue: Int {
         return key.lowercased().hashValue
+    }
+}
+
+extension HeaderKey: Equatable {
+    static public func ==(lhs: HeaderKey, rhs: HeaderKey) -> Bool {
+        return lhs.key.lowercased() == rhs.key.lowercased()
     }
 }
 
@@ -279,10 +283,6 @@ extension HeaderKey {
   static public var wwwAuthenticate: HeaderKey {
     return HeaderKey("WWW-Authenticate")
   }
-}
-
-public func ==(lhs: HeaderKey, rhs: HeaderKey) -> Bool {
-    return lhs.key.lowercased() == rhs.key.lowercased()
 }
 
 extension HeaderKey: ExpressibleByStringLiteral {

--- a/Sources/HTTP/Models/Headers/Headers.swift
+++ b/Sources/HTTP/Models/Headers/Headers.swift
@@ -28,7 +28,7 @@ public struct HeaderKey {
     }
 }
 
-extension HeaderKey: CustomDebugStringConvertible {
+extension HeaderKey: CustomStringConvertible {
     public var description: String {
         return key
     }

--- a/Sources/HTTP/Models/Status/Status.swift
+++ b/Sources/HTTP/Models/Status/Status.swift
@@ -302,7 +302,7 @@ extension Status {
         case .notExtended:                   return "Not Extended"
         case .networkAuthenticationRequired: return "Network Authentication Required"
 
-        case .other(_, let reasonPhrase):      return reasonPhrase
+        case .other(_, let reasonPhrase):    return reasonPhrase
         }
     }
 }


### PR DESCRIPTION
## Things done (Just improvements)
- [x] Conformance to protocol is done at the site/extension where it is declared. 
- [x] Moved equatable conformance to a static method rather than a global func.
- [x] Some minor indentation fixes. 

