### PR TITLE
Add percent encoding to url path with .urlPathAllowed characters

### DIFF
--- a/Sources/HTTP/Models/Request/Request.swift
+++ b/Sources/HTTP/Models/Request/Request.swift
@@ -36,7 +36,7 @@ public final class Request: Message {
 
         // https://tools.ietf.org/html/rfc7230#section-3.1.2
         // status-line = HTTP-version SP status-code SP reason-phrase CRL
-        var path = uri.path
+        var path = uri.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? uri.path
         if let q = uri.query, !q.isEmpty {
             let encoded = q.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
             path += "?\(encoded ?? "")"


### PR DESCRIPTION
When parsing an URI from a string, it's decoded and it's percent encoding is lost, causing some urls to fail (when using %20 to replace an space, for example).

I modified a line to add percent encoding to the path when it's being built.

In the strange case that `addingPercentEncoding` returns `nil`, the path is used without modification, like it was being used before this commit.