### PR TITLE
fix http client sending body twice

### DIFF
--- a/Sources/HTTP/Serializer/RequestSerializer.swift
+++ b/Sources/HTTP/Serializer/RequestSerializer.swift
@@ -50,13 +50,6 @@ public final class RequestSerializer: ByteSerializer {
             
             try serialize(&request.headers, into: &buffer, for: request.body)
             
-            switch request.body {
-            case .chunked:
-                break
-            case .data(let bytes):
-                try fill(bytes, into: &buffer)
-            }
-            
             done = true
             return pointer
         } catch ByteSerializerError.bufferFull {


### PR DESCRIPTION
- The request serializer was not updated appropriately to match the response serializer's changes in https://github.com/vapor/engine/pull/137
- Fixes https://github.com/vapor/engine/issues/139