### PR TITLE
Update sources to newer core

### DIFF
--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -1,3 +1,4 @@
+import Core
 import Dispatch
 import HTTP
 import TCP
@@ -10,8 +11,8 @@ server.then { client in
     client.map(parser.parse).map { request in
         return HTTP.Response(status: 200)
     }.then(client.send)
-
-    client.listen()
+    
+    return Future(client.listen)
 }
 
 try server.start()

--- a/Sources/HTTP/RequestParser.swift
+++ b/Sources/HTTP/RequestParser.swift
@@ -20,19 +20,12 @@ public final class RequestParser: Core.Stream, CParser {
         http_parser_init(&parser, HTTP_REQUEST)
         initialize(&settings)
     }
-
-    /// Internal typealias used to define a cascading callback
-    typealias ProcessOutputCallback = ((Output) throws -> ())
-
-    /// All entities waiting for a new packet
-    var branchStreams = [ProcessOutputCallback]()
-
-    public func map<T>(_ closure: @escaping ((Request) throws -> (T?))) -> StreamTransformer<Request, T> {
-        let stream = StreamTransformer<Output, T>(using: closure)
-        branchStreams.append(stream.process)
-        return stream
+    
+    let stream = BasicStream<Output>()
+    
+    public func then(_ closure: @escaping ((Request) throws -> (Future<Void>))) {
+        stream.then(closure)
     }
-
 
     /// Parses a Request from the stream.
     public func parse(from buffer: ByteBuffer) throws -> Request? {

--- a/Sources/HTTP/Response.swift
+++ b/Sources/HTTP/Response.swift
@@ -147,17 +147,17 @@ extension Client : HTTPRemote {
 
             let buffer = UnsafeRawBufferPointer(start: pointer, count: consumed)
             let dispatchData = DispatchData(bytes: buffer)
-            write(dispatchData)
+            try write(dispatchData)
             // try socket.write(max: consumed, from: buffer)
         } else {
             let buffer = UnsafeRawBufferPointer(start: pointer, count: consumed)
             let dispatchData = DispatchData(bytes: buffer)
-            write(dispatchData)
+            try write(dispatchData)
             
             if let body = body {
                 let buffer = UnsafeRawBufferPointer(start: body.buffer.baseAddress, count: body.buffer.count)
                 let dispatchData = DispatchData(bytes: buffer)
-                write(dispatchData)
+                try write(dispatchData)
             }
         }
     }

--- a/Sources/TCP/Client.swift
+++ b/Sources/TCP/Client.swift
@@ -7,9 +7,6 @@ import libc
 public final class Client: Core.Stream {
     let socket: Socket
 
-    public typealias OnRead = (ByteBuffer) -> ()
-    public var onRead: OnRead?
-
     /// A closure that can be called whenever the socket encountered a critical error
     public var onError: ((Error) -> ())? = nil
 
@@ -36,16 +33,22 @@ public final class Client: Core.Stream {
         let writeSource = DispatchSource.makeWriteSource(fileDescriptor: socket.descriptor, queue: writeQueue)
         self.writeQueue = writeQueue
         self.writeSource = writeSource
-
+        
         writeSource.setEventHandler {
-            guard let data = self.writeData else {
+            guard let (data, callback) = self.input else {
                 return
             }
-            self.writeData = nil
-            let copied = Data(data)
-            let buffer = ByteBuffer.init(start: copied.withUnsafeBytes { $0 }, count: copied.count)
-            try! self.socket.write(max: copied.count, from: buffer)
+            
+            defer { self.input = nil }
+            
+            do {
+                let buffer = ByteBuffer.init(start: data.withUnsafeBytes { $0 }, count: data.count)
+                try self.socket.write(max: data.count, from: buffer)
+            } catch {
+                _ = try? callback.complete(error)
+            }
         }
+        
         writeSource.resume()
     }
 
@@ -54,14 +57,14 @@ public final class Client: Core.Stream {
 
     let writeQueue: DispatchQueue
     let writeSource: DispatchSourceWrite
-    var writeData: DispatchData?
+    var input: (DispatchData, ManualFuture<Void>)?
 
-    public func write(_ data: DispatchData) {
-        if writeData == nil {
-            writeData = data
-        } else {
-            writeData?.append(data)
-        }
+    public func write(_ data: DispatchData) throws {
+        let future = ManualFuture<Void>()
+        
+        self.input = (data, future)
+        
+        try future.await()
     }
 
     public func close() {
@@ -95,11 +98,8 @@ public final class Client: Core.Stream {
                 start: self.pointer,
                 count: self.read
             )
-
-            self.onRead?(buffer)
-            self.branchStreams.forEach { stream in
-                _ = try? stream(buffer)
-            }
+            
+            _ = try? self.stream.write(buffer)
         }
 
         readSource.resume()
@@ -121,17 +121,14 @@ public final class Client: Core.Stream {
 
     public typealias Output = ByteBuffer
 
-    /// Internal typealias used to define a cascading callback
-    typealias ProcessOutputCallback = ((Output) throws -> ())
+    /// The underlying stream helper
+    let stream = BasicStream<Output>()
 
-    /// All entities waiting for a new packet
-    var branchStreams = [ProcessOutputCallback]()
-
-    /// Maps this stream of data to a stream of other information
-    public func map<T>(_ closure: @escaping ((Output) throws -> (T?))) -> StreamTransformer<Output, T> {
-        let stream = StreamTransformer<Output, T>(using: closure)
-        branchStreams.append(stream.process)
-        return stream
+    /// Registers a closure that must be executed for every `Output` event
+    ///
+    /// - parameter closure: The closure to execute for each `Output` event
+    public func then(_ closure: @escaping ((ByteBuffer) throws -> (Future<Void>))) {
+        stream.then(closure)
     }
 }
 

--- a/Sources/TCP/Server.swift
+++ b/Sources/TCP/Server.swift
@@ -88,9 +88,7 @@ public final class Server: Stream {
                 self.clients[clientDescriptor] = client
             }
 
-            self.branchStreams.forEach { branch in
-                try! branch(client)
-            }
+            _ = try? self.stream.write(client)
         }
 
         connectSource.resume()
@@ -100,17 +98,10 @@ public final class Server: Stream {
 
     public typealias Output = Client
 
-    /// Internal typealias used to define a cascading callback
-    typealias ProcessOutputCallback = ((Output) throws -> ())
-
-    /// All entities waiting for a new packet
-    var branchStreams = [ProcessOutputCallback]()
-
-    /// Maps this stream of data to a stream of other information
-    public func map<T>(_ closure: @escaping ((Output) throws -> (T?))) -> StreamTransformer<Output, T> {
-        let stream = StreamTransformer<Output, T>(using: closure)
-        branchStreams.append(stream.process)
-        return stream
+    let stream = BasicStream<Client>()
+    
+    public func then(_ closure: @escaping ((Client) throws -> (Future<Void>))) {
+        stream.then(closure)
     }
 }
 


### PR DESCRIPTION
It also cleans up the code by using `BaseStream` more frequently, preventing code duplication