### PR TITLE
fix queue performance

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         // Core extensions, type-aliases, and functions that facilitate common tasks.
-        .package(url: "https://github.com/vapor/core.git", .revision("beta")),
+        .package(url: "https://github.com/vapor/core.git", .revision("async-file")),
 
         // A library to aid Vapor users with better debugging around the framework
         .package(url: "https://github.com/vapor/debugging.git", .revision("beta"))

--- a/Sources/HTTP/Responder/Responder.swift
+++ b/Sources/HTTP/Responder/Responder.swift
@@ -9,11 +9,8 @@ public protocol Responder {
 extension Responder {
     /// Creates a stream from this responder capable of being
     /// added to a server or client stream.
-    public func makeStream(on queue: DispatchQueue) -> ResponderStream {
-        return ResponderStream(
-            responder: self,
-            queue: queue
-        )
+    public func makeStream() -> ResponderStream {
+        return ResponderStream(responder: self)
     }
 }
 
@@ -34,14 +31,10 @@ public final class ResponderStream: Core.Stream {
     /// The responder
     let responder: Responder
 
-    /// The queue on which responses will be awaited
-    let queue: DispatchQueue
-
     /// Create a new response stream.
     /// The responses will be awaited on the supplied queue.
-    public init(responder: Responder, queue: DispatchQueue) {
+    public init(responder: Responder) {
         self.responder = responder
-        self.queue = queue
     }
 
     /// Handle incoming requests.
@@ -49,7 +42,7 @@ public final class ResponderStream: Core.Stream {
         do {
             // dispatches the incoming request to the responder.
             // the response is awaited on the responder stream's queue.
-            try responder.respond(to: input).then(on: queue) { res in
+            try responder.respond(to: input).then { res in
                 self.outputStream?(res)
             }.catch { error in
                 self.errorStream?(error)

--- a/Sources/TCP/Socket/Socket+Async.swift
+++ b/Sources/TCP/Socket/Socket+Async.swift
@@ -6,10 +6,9 @@ public typealias SocketEvent = () -> ()
 extension Socket {
     /// The socket event will be called on the supplied queue
     /// whenever this socket can be read from.
-    public func onReadable(queue: DispatchQueue, event: @escaping SocketEvent) -> DispatchSourceRead {
+    public func onReadable(event: @escaping SocketEvent) -> DispatchSourceRead {
         let source = DispatchSource.makeReadSource(
-            fileDescriptor: descriptor.raw,
-            queue: queue
+            fileDescriptor: descriptor.raw
         )
         source.setEventHandler {
             event()
@@ -21,11 +20,8 @@ extension Socket {
 
     /// The socket event will be called on the supplied queue
     /// whenever this socket can be written to.
-    public func onWriteable(queue: DispatchQueue, event: @escaping SocketEvent) -> DispatchSourceWrite {
-        let source = DispatchSource.makeWriteSource(
-            fileDescriptor: descriptor.raw,
-            queue: queue
-        )
+    public func onWriteable(event: @escaping SocketEvent) -> DispatchSourceWrite {
+        let source = DispatchSource.makeWriteSource(fileDescriptor: descriptor.raw)
         source.setEventHandler {
             event()
         }

--- a/Sources/TCP/Streams/Client.swift
+++ b/Sources/TCP/Streams/Client.swift
@@ -11,11 +11,6 @@ public final class Client: Core.Stream {
     public var errorStream: ErrorHandler?
     public var outputStream: OutputHandler?
 
-    /// This client's dispatch queue. Use this
-    /// for all async operations performed as a
-    /// result of this client.
-    public let queue: DispatchQueue
-
     /// The client stream's underlying socket.
     public let socket: Socket
 
@@ -36,9 +31,8 @@ public final class Client: Core.Stream {
     var onClose: SocketEvent?
 
     /// Creates a new Remote Client from the ServerSocket's details
-    public init(socket: Socket, queue: DispatchQueue) {
+    public init(socket: Socket) {
         self.socket = socket
-        self.queue = queue
 
         // Allocate one TCP packet
         let size = 65_507
@@ -58,7 +52,7 @@ public final class Client: Core.Stream {
         }
 
         if writeSource == nil {
-            writeSource = socket.onWriteable(queue: queue) {
+            writeSource = socket.onWriteable {
                 // important: make sure to suspend or else writeable
                 // will keep calling.
                 self.writeSource?.suspend()
@@ -87,7 +81,7 @@ public final class Client: Core.Stream {
 
     /// Starts receiving data from the client
     public func start() {
-        readSource = socket.onReadable(queue: queue) {
+        readSource = socket.onReadable {
             let read: Int
             do {
                 read = try self.socket.read(

--- a/Sources/TCP/Streams/Server.swift
+++ b/Sources/TCP/Streams/Server.swift
@@ -8,36 +8,20 @@ public final class Server: Core.OutputStream {
     public typealias Output = Client
     public var errorStream: ErrorHandler?
     public var outputStream: OutputHandler?
-
-    // MARK: Dispatch
-
-    /// The dispatch queue that peers are accepted on.
-    public let queue: DispatchQueue
-
     // MARK: Internal
 
     let socket: Socket
-    let workers: [DispatchQueue]
-    var worker: LoopIterator<[DispatchQueue]>
     var readSource: DispatchSourceRead?
 
     /// Creates a TCP server from an existing TCP socket.
-    public init(socket: Socket, workerCount: Int) {
+    public init(socket: Socket) {
         self.socket = socket
-        self.queue = DispatchQueue(label: "codes.vapor.net.tcp.server.main", qos: .userInteractive)
-        var workers: [DispatchQueue] = []
-        for i in 1...workerCount {
-            let worker = DispatchQueue(label: "codes.vapor.net.tcp.server.worker.\(i)", qos: .userInteractive)
-            workers.append(worker)
-        }
-        worker = LoopIterator(collection: workers)
-        self.workers = workers
     }
 
     /// Creates a new Server Socket
-    public convenience init(workerCount: Int = 8) throws {
+    public convenience init() throws {
         let socket = try Socket()
-        self.init(socket: socket, workerCount: workerCount)
+        self.init(socket: socket)
     }
 
     /// Starts listening for peers asynchronously
@@ -47,7 +31,7 @@ public final class Server: Core.OutputStream {
         try socket.bind(hostname: hostname, port: port)
         try socket.listen(backlog: backlog)
 
-        readSource = socket.onReadable(queue: queue) {
+        readSource = socket.onReadable {
             let socket: Socket
             do {
                 socket = try self.socket.accept()
@@ -56,8 +40,7 @@ public final class Server: Core.OutputStream {
                 return
             }
 
-            let queue = self.worker.next()!
-            let client = Client(socket: socket, queue: queue)
+            let client = Client(socket: socket)
             client.errorStream = self.errorStream
             self.outputStream?(client)
         }


### PR DESCRIPTION
dispatching promises on queues seems like it's slowing the app down. removing all `on: queue` calls from `.then` and `.catch` took engine from ~30k/s back to ~100k/s. 

we should look into whether its okay for the work to be done for all awaiters when `promise.complete` is called. (we can also not lock on this method since that could potentially block).