### PR TITLE
Allow `stringValue` on `ArrayKey`

### DIFF
--- a/Sources/FormURLEncoded/ArrayKey.swift
+++ b/Sources/FormURLEncoded/ArrayKey.swift
@@ -6,7 +6,7 @@ struct ArrayKey {
 }
 
 extension ArrayKey: CodingKey {
-    var stringValue: String { fatalError() }
+    var stringValue: String { return String(index) }
     init?(stringValue: String) { fatalError() }
     var intValue: Int? { return index }
     init?(intValue: Int) { fatalError() }

--- a/Tests/HTTPTests/HTTPServerTests.swift
+++ b/Tests/HTTPTests/HTTPServerTests.swift
@@ -1,5 +1,6 @@
 import Async
 import Bits
+import Dispatch
 import HTTP
 import Foundation
 import TCP

--- a/Tests/HTTPTests/HTTPServerTests.swift
+++ b/Tests/HTTPTests/HTTPServerTests.swift
@@ -36,18 +36,11 @@ class HTTPServerTests: XCTestCase {
         )
         server.onError = { XCTFail("\($0)") }
 
-        if #available(OSX 10.12, *) {
-            Thread.detachNewThread {
-                accept.run()
-            }
-            for worker in workers {
-                Thread.detachNewThread {
-                    worker.eventLoop.run()
-                }
-            }
-        } else {
-            fatalError()
-        }
+        let acceptItem = DispatchWorkItem(block: accept.run)
+        let workerItems = workers.map { DispatchWorkItem(block: $0.eventLoop.run) }
+
+        DispatchQueue.global().async(execute: acceptItem)
+        workerItems.forEach { DispatchQueue.global().async(execute: $0) }
 
         // beyblades let 'er rip
         try tcpServer.start(hostname: "localhost", port: 8123, backlog: 128)
@@ -71,6 +64,9 @@ class HTTPServerTests: XCTestCase {
 
 
         waitForExpectations(timeout: 5)
+
+        acceptItem.cancel()
+        workerItems.forEach { $0.cancel() }
         tcpServer.stop()
     }
 

--- a/Tests/TLSTests/SSLTests.swift
+++ b/Tests/TLSTests/SSLTests.swift
@@ -12,8 +12,6 @@ import XCTest
 class SSLTests: XCTestCase {
     func testClientBlocking() { do { try _testClientBlocking() } catch { XCTFail("\(error)") } }
     func _testClientBlocking() throws {
-
-
         let tcpSocket = try TCPSocket(isNonBlocking: false)
         let tcpClient = try TCPClient(socket: tcpSocket)
         let tlsSettings = TLSClientSettings()
@@ -23,7 +21,7 @@ class SSLTests: XCTestCase {
             let tlsClient = try AppleTLSClient(tcp: tcpClient, using: tlsSettings)
         #endif
         try tlsClient.connect(hostname: "google.com", port: 443)
-        // try tlsClient.socket.handshake()
+        try tlsClient.socket.prepareSocket()
         let req = "GET /robots.txt HTTP/1.1\r\nContent-Length: 0\r\nHost: www.google.com\r\nUser-Agent: hi\r\n\r\n".data(using: .utf8)!
         _ = try tlsClient.socket.write(from: req.withByteBuffer { $0 })
         var res = Data(count: 4096)


### PR DESCRIPTION
All other `CodingKey`s encountered in the wild implement `stringValue` for integer keys (see `JSONEncoder`'s `_JSONKey`: https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/JSONEncoder.swift#L2126). A common pattern for printing coding paths for debugging is `codingPath.map{$0.stringValue}` - this change allows that pattern to function with `FormURLEncoder`.