### PR TITLE
[V3] Fix parsing WebSocket close frame length

### DIFF
--- a/Sources/WebSocket/FrameParser.swift
+++ b/Sources/WebSocket/FrameParser.swift
@@ -208,7 +208,7 @@ final class FrameParser: ByteParser {
                 return nil
             }
             
-            guard consumed &+ 4 < length else {
+            guard consumed &+ 4 <= length else {
                 // throw an invalidFrame for a missing mask buffer
                 throw WebSocketError(.invalidMask)
             }

--- a/Sources/WebSocket/FrameParser.swift
+++ b/Sources/WebSocket/FrameParser.swift
@@ -202,15 +202,15 @@ final class FrameParser: ByteParser {
         let mask: [UInt8]?
         
         if isMasked {
+            guard consumed &+ 4 <= length else {
+                // throw an invalidFrame for a missing mask buffer
+                throw WebSocketError(.invalidMask)
+            }
+
             // Ensure the minimum length is available
             guard length &- consumed >= payloadLength &+ 4, payloadLength < Int.max else {
                 // throw an invalidFrame for incomplete/invalid
                 return nil
-            }
-            
-            guard consumed &+ 4 <= length else {
-                // throw an invalidFrame for a missing mask buffer
-                throw WebSocketError(.invalidMask)
             }
             
             mask = [base[0], base[1], base[2], base[3]]


### PR DESCRIPTION
Without this patch, I get the following error when sending a Close frame without a payload to an Engine WebSocket server:

> ⚠️ [WebSocket.WebSocketError.invalidMask: Masks must be 4 bytes, no more, no less] [/Users/redacted/.build/checkouts/engine.git-3311994267206676365/Sources/WebSocket/FrameParser.swift:213:39] [Possible causes: The mask provided was not 4 bytes long as per standard] [Suggested fixes: Generate 4 random bytes using any Random Number Generator for clients,Leave the mask empty (`nil`) for servers]

See commit messages for details on my changes.