### PR TITLE
Add HTTP 418 "I'm a teapot" support to CHTTP

### DIFF
--- a/Sources/CHTTP/include/http_parser.h
+++ b/Sources/CHTTP/include/http_parser.h
@@ -131,6 +131,7 @@ typedef int (*http_cb) (http_parser*);
   XX(415, UNSUPPORTED_MEDIA_TYPE,          Unsupported Media Type)          \
   XX(416, RANGE_NOT_SATISFIABLE,           Range Not Satisfiable)           \
   XX(417, EXPECTATION_FAILED,              Expectation Failed)              \
+  XX(418, IM_A_TEAPOT,                     I'\''m a teapot)                 \
   XX(421, MISDIRECTED_REQUEST,             Misdirected Request)             \
   XX(422, UNPROCESSABLE_ENTITY,            Unprocessable Entity)            \
   XX(423, LOCKED,                          Locked)                          \


### PR DESCRIPTION
Add definition for [RFC 2324](https://tools.ietf.org/html/rfc2324) `I'm a teapot` to CHTTP's `http_parser.h`. This is already supported throughout the rest of Engine, but I noticed that it was missing from here. Given that it's **_such a critical_** part of the HTTP spec, we **_simply can't_** leave it missing. 😜