### PR TITLE
Fix issue where larger responses hang

### DIFF
--- a/Sources/HTTP/Serializer/HTTPSerializer.swift
+++ b/Sources/HTTP/Serializer/HTTPSerializer.swift
@@ -146,7 +146,7 @@ extension HTTPSerializer {
                 write(message, downstream, nextMessage)
             } else {
                 context.state = then
-                try serialize(message, downstream, nextMessage)
+                write(message, downstream, nextMessage)
             }
             remainingStartLine.deallocate()
           


### PR DESCRIPTION
With larger HTTP bodies, the `continueBuffer` state was not being
handled correctly, causing the last chunk to not be sent.

Fixes vapor/vapor#1492 and probably some others.