### PR TITLE
Remove redundant code in HTTPSerializer

### DIFF
--- a/Sources/HTTP/Serializer/HTTPSerializer.swift
+++ b/Sources/HTTP/Serializer/HTTPSerializer.swift
@@ -143,13 +143,11 @@ extension HTTPSerializer {
         case .continueBuffer(let remainingStartLine, let then):
             if let remaining = context.append(remainingStartLine) {
                 context.state = .continueBuffer(remaining.allocateAndInitializeCopy(), nextState: then)
-                write(message, downstream, nextMessage)
             } else {
                 context.state = then
-                write(message, downstream, nextMessage)
             }
+            write(message, downstream, nextMessage)
             remainingStartLine.deallocate()
-          
         case .streaming(let stream):
             write(message, stream, downstream, nextMessage, .done)
         case .done:


### PR DESCRIPTION
Just a small change that makes the fix implemented by PR #222 more pretty.