### PR TITLE
Adds `future.send(to: Websocket)`

### DIFF
--- a/Sources/WebSocket/WebSocket.swift
+++ b/Sources/WebSocket/WebSocket.swift
@@ -235,3 +235,21 @@ public final class WebSocket {
         }
     }
 }
+
+extension Future where Expectation == String {
+    public func send(to websocket: WebSocket) -> Future<Expectation> {
+        return self.flatMap(to: Expectation.self) { (data) in
+            websocket.send(string: data)
+            return self
+        }
+    }
+}
+
+extension Future where Expectation == Data {
+    public func send(to websocket: WebSocket) -> Future<Expectation> {
+        return self.flatMap(to: Expectation.self) { (data) in
+            websocket.send(data: data)
+            return self
+        }
+    }
+}


### PR DESCRIPTION
Should ease the integration of Websockets into promise chains. Websockets don't mesh well with futures in general right now, but these convenience functions ought to help a bit.

Example usage:
```
router.websocket("message") { (req, websocket) in
    websocket.onString { (ws, msg) in
        let decoder = JSONDecoder()
        let encoder = JSONEncoder()
        let message = try decoder.decode(Message.self, from: msg.data(using: .utf8)!)
        
        req.withPooledConnection(to: .psql, closure: { (conn) in
            return conn
                .query(Message.self)
                .save(message)
                .flatMap(to: [Message].self) { (_) -> Future<[Message]> in
                    return conn.query(Message.self).all()
                }.map(to: String.self) { (allMessages) in
                    guard let allJSONMessages = try encoder.encode(allMessages).toString()
                        else {throw Abort(.internalServerError)}
                    return allJSONMessages
                }.send(to: ws) // This is the addition
                .catch({ (err) in
                    print(err)
                })
        })
    }
}
```