### PR TITLE
Adds three new `.send()` methods that take Futures

### DIFF
--- a/Sources/WebSocket/WebSocket.swift
+++ b/Sources/WebSocket/WebSocket.swift
@@ -189,6 +189,24 @@ public final class WebSocket {
         self.serializerStream.push(frame)
     }
     
+    public func send(future: Future<String>) -> Void {
+        _ = future.map(to: Void.self) { (msg) -> Void in
+            self.send(string: msg)
+        }
+    }
+
+    public func send(future: Future<Data>) -> Void {
+        _ = future.map(to: Void.self) { (msg) -> Void in
+            self.send(data: msg)
+        }
+    }
+
+    public func send(future: Future<ByteBuffer>) -> Void {
+        _ = future.map(to: Void.self) { (msg) -> Void in
+            self.send(bytes: msg)
+        }
+    }
+    
     @discardableResult
     public func ping() -> Future<Void> {
         let promise = Promise<Void>()


### PR DESCRIPTION
Adds `send(future: Future<String>)`, `send(future: Future<Data>)`, `send(future: Future<ByteBuffer>)`

Example usage:

```swift
let allJSONMessagesFuture = req.withPooledConnection(to: .psql, closure: { (conn) in
    return conn
        .query(Message.self)
        .save(message)
        .flatMap(to: [Message].self) { (_) -> Future<[Message]> in
            return conn.query(Message.self).all()
        }.map(to: String.self) { (allMessages) in
            guard let allJSONMessages = try encoder.encode(allMessages).toString()
                else {throw Abort(.internalServerError)}
            return allJSONMessages
        }.catch({ (err) in
            print(err)
        })
})

ws.send(future: allJSONMessagesFuture)
```