### PR TITLE
Allow session to be passed in

### DIFF
--- a/Sources/HTTP/FoundationClient/Client+Foundation.swift
+++ b/Sources/HTTP/FoundationClient/Client+Foundation.swift
@@ -16,7 +16,7 @@ public final class FoundationClient: Client {
         scheme: String,
         hostname: String,
         port: Transport.Port,
-        session: URLSession
+        session: URLSession = URLSession(configuration: .default)
     ) {
         self.scheme = scheme
         self.hostname = hostname
@@ -45,20 +45,5 @@ public final class FoundationClient: Client {
             }
             task.resume()
         }
-    }
-}
-
-public extension FoundationClient {
-    public convenience init(
-        scheme: String,
-        hostname: String,
-        port: Transport.Port
-    ) {
-        self.init(
-            scheme: scheme,
-            hostname: hostname,
-            port: port,
-            session: URLSession(configuration: .default)
-        )
     }
 }

--- a/Sources/HTTP/FoundationClient/Client+Foundation.swift
+++ b/Sources/HTTP/FoundationClient/Client+Foundation.swift
@@ -15,12 +15,13 @@ public final class FoundationClient: Client {
     public init(
         scheme: String,
         hostname: String,
-        port: Transport.Port
+        port: Transport.Port,
+        session: URLSession
     ) {
         self.scheme = scheme
         self.hostname = hostname
         self.port = port
-        self.session = URLSession(configuration: .default)
+        self.session = session
     }
 
     /// responds to the request using URLResponse
@@ -44,5 +45,20 @@ public final class FoundationClient: Client {
             }
             task.resume()
         }
+    }
+}
+
+public extension FoundationClient {
+    public convenience init(
+        scheme: String,
+        hostname: String,
+        port: Transport.Port
+    ) {
+        self.init(
+            scheme: scheme,
+            hostname: hostname,
+            port: port,
+            session: URLSession(configuration: .default)
+        )
     }
 }


### PR DESCRIPTION
In my current project I ran into an issue where I needed to proxy using https. I wasn't able to do this  and after speaking with @tanner0101 he suggested the I looked into `URLSession`. Using the proxy configuration for `URLSession` allowed me to do what I wanted to do.

This PR would make the `FoundationClient` more flexible since one could pass in their own configured `URLSession`. AFAIK this PR shouldn't break any public API's.