### PR TITLE
Use source parameter as SourceLocation for `HTTPError`s

### DIFF
--- a/Sources/HTTP/Utilities/Error.swift
+++ b/Sources/HTTP/Utilities/Error.swift
@@ -27,7 +27,7 @@ public struct HTTPError: Debuggable {
         return HTTPError(
             identifier: "invalidMessage",
             reason: "Unable to parse invalid HTTP message.",
-            source: .capture()
+            source: source
         )
     }
 
@@ -38,7 +38,7 @@ public struct HTTPError: Debuggable {
         return HTTPError(
             identifier: "contentRequired",
             reason: "\(type) content required.",
-            source: .capture()
+            source: source
         )
     }
 }


### PR DESCRIPTION
I _think_ this is the desired behaviour, otherwise providing the `source` parameter to the `HTTPError` seems redundant