### PR TITLE
Avoid double encoding of query params when using FoundationClient

### DIFF
--- a/Sources/HTTP/FoundationClient/URI+Foundation.swift
+++ b/Sources/HTTP/FoundationClient/URI+Foundation.swift
@@ -14,7 +14,7 @@ extension URI {
         comps.host = hostname.isEmpty ? nil : hostname
         comps.port = port.flatMap(Int.init)
         comps.path = path
-        comps.query = query
+        comps.query = query?.percentDecoded
         comps.fragment = fragment
         guard let url = comps.url else { throw ConversionError.unableToMakeFoundationURL }
         return url


### PR DESCRIPTION
Currently when using `FoundationClient` query params will be encoded twice since Vapor has already percent-encoded the query at the same it's set to `URLComponents`. Since the value is expected to not be percent-encoded at the time of assignment I suggest a naive solution where we simple decode it before setting it. I do not have an overview of any potential implications which is why I suggested this on Slack where @tanner0101 seemed fine with the approach.

Please note that I created a `vapor-2` (based on the 2.2.3 release)  branch in order to be able to open this PR. Let me know if you had another branching strategy in mind.