### PR TITLE
addHTTPServerHandlers is deprecated in nio 1.2.1

### DIFF
--- a/Sources/HTTP/HTTPServer.swift
+++ b/Sources/HTTP/HTTPServer.swift
@@ -45,7 +45,7 @@ public final class HTTPServer {
             // Set the handlers that are applied to the accepted Channels
             .childChannelInitializer { channel in
                 // re-use subcontainer for an event loop here
-                return channel.pipeline.addHTTPServerHandlers().then {
+                return channel.pipeline.configureHTTPServerPipeline().then {
                     let handler = HTTPServerHandler(responder: responder, maxBodySize: maxBodySize, onError: onError)
                     return channel.pipeline.add(handler: handler)
                 }


### PR DESCRIPTION
addHTTPServerHandlers is deprecated in nio 1.2.1.
It is the only compiler warning when compiling Vapor bio branch with bio 1.2.1.