### PR TITLE
Fix serializing cookies logic

### DIFF
--- a/Sources/HTTP/HTTPCookies.swift
+++ b/Sources/HTTP/HTTPCookies.swift
@@ -144,7 +144,7 @@ extension HTTPCookies {
         }
 
         let cookie: String = map { cookie in
-            return "\(cookie.name)=\(cookie.value)"
+            return "\(cookie.name)=\(cookie.value.string)"
         }.joined(separator: "; ")
 
         request.headers.replaceOrAdd(name: .cookie, value: cookie)


### PR DESCRIPTION
I fixed logic to set cookie in request header.
That needs to be set String, not HTTPCookieValue