### PR TITLE
add support for enabling HTTP pipelining

### DIFF
--- a/Tests/HTTPTests/HTTPClientTests.swift
+++ b/Tests/HTTPTests/HTTPClientTests.swift
@@ -26,8 +26,8 @@ class HTTPClientTests: XCTestCase {
         try testURL("http://zombo.com", contains: "<title>ZOMBO</title>")
     }
 
-    func testAmazonWithTLS() throws {
-        try testURL("https://www.amazon.com", contains: "Amazon.com, Inc.")
+    func testVaporWithTLS() throws {
+        try testURL("https://vapor.codes", contains: "Server-side Swift")
     }
 
     func testQuery() throws {
@@ -41,7 +41,7 @@ class HTTPClientTests: XCTestCase {
         ("testGoogleAPIsFCM", testGoogleAPIsFCM),
         ("testExampleCom", testExampleCom),
         ("testZombo", testZombo),
-        ("testAmazonWithTLS", testAmazonWithTLS),
+        ("testVaporWithTLS", testVaporWithTLS),
         ("testQuery", testQuery),
     ]
 }

--- a/Tests/HTTPTests/HTTPTests.swift
+++ b/Tests/HTTPTests/HTTPTests.swift
@@ -95,8 +95,6 @@ class HTTPTests: XCTestCase {
             func upgrade(ctx: ChannelHandlerContext, upgradeResponse: HTTPResponseHead) -> EventLoopFuture<String> {
                 return ctx.eventLoop.future("hello")
             }
-            
-            
         }
         do {
             _ = try HTTPClient.upgrade(hostname: "foo", upgrader: FakeUpgrader(), on: worker).wait()


### PR DESCRIPTION
- [x] Adds a new option `supportPipelining` to `HTTPServer.start`.
- [x] Fixes #318 
- [x] Adds a debug-only assertion when pipelining is detected in `HTTPServerHandler`.
- [x] Changes TLS test to `vapor.codes` since Amazon's TLS seems to be unreliable.