### PR TITLE
Specify host port when different from scheme default port

### DIFF
--- a/Sources/HTTPKit/Client/HTTPClient.swift
+++ b/Sources/HTTPKit/Client/HTTPClient.swift
@@ -69,7 +69,8 @@ public final class HTTPClient {
     
     public func send(_ request: HTTPRequest) -> EventLoopFuture<HTTPResponse> {
         let hostname = request.url.host ?? ""
-        let port = request.url.port ?? (request.url.scheme == "https" ? 443 : 80)
+        let defaultSchemePort = request.url.scheme == "https" ? 443 : 80
+        let port = request.url.port ?? defaultSchemePort
         let tlsConfig: TLSConfiguration?
         switch request.url.scheme {
         case "https":
@@ -139,7 +140,13 @@ public final class HTTPClient {
             handlers.append(("client-decoder", clientResDecoder))
             httpHandlerNames.append("client-decoder")
             
-            let clientReqEncoder = HTTPClientRequestEncoder(hostname: hostname)
+            let clientReqEncoder: HTTPClientRequestEncoder
+            if port == defaultSchemePort {
+                clientReqEncoder = HTTPClientRequestEncoder(host: hostname)
+            } else {
+                clientReqEncoder = HTTPClientRequestEncoder(host: "\(hostname):\(port)")
+            }
+            
             handlers.append(("client-encoder", clientReqEncoder))
             httpHandlerNames.append("client-encoder")
             

--- a/Sources/HTTPKit/Client/HTTPClient.swift
+++ b/Sources/HTTPKit/Client/HTTPClient.swift
@@ -145,9 +145,9 @@ public final class HTTPClient {
             // See https://tools.ietf.org/html/rfc2616#section-14.23
             let clientReqEncoder: HTTPClientRequestEncoder
             if port == defaultSchemePort {
-                clientReqEncoder = HTTPClientRequestEncoder(host: hostname)
+                clientReqEncoder = HTTPClientRequestEncoder(hostHeaderValue: hostname)
             } else {
-                clientReqEncoder = HTTPClientRequestEncoder(host: "\(hostname):\(port)")
+                clientReqEncoder = HTTPClientRequestEncoder(hostHeaderValue: "\(hostname):\(port)")
             }
             
             handlers.append(("client-encoder", clientReqEncoder))

--- a/Sources/HTTPKit/Client/HTTPClient.swift
+++ b/Sources/HTTPKit/Client/HTTPClient.swift
@@ -140,6 +140,9 @@ public final class HTTPClient {
             handlers.append(("client-decoder", clientResDecoder))
             httpHandlerNames.append("client-decoder")
             
+            // When port is different from the default port for the scheme
+            // it must be explicitly specified in the `Host` HTTP header.
+            // See https://tools.ietf.org/html/rfc2616#section-14.23
             let clientReqEncoder: HTTPClientRequestEncoder
             if port == defaultSchemePort {
                 clientReqEncoder = HTTPClientRequestEncoder(host: hostname)

--- a/Sources/HTTPKit/Client/HTTPClientRequestEncoder.swift
+++ b/Sources/HTTPKit/Client/HTTPClientRequestEncoder.swift
@@ -3,18 +3,18 @@ internal final class HTTPClientRequestEncoder: ChannelOutboundHandler, Removable
     typealias OutboundIn = HTTPRequest
     typealias OutboundOut = HTTPClientRequestPart
 
-    let host: String
+    let hostHeaderValue: String
     
     /// Creates a new `HTTPClientRequestSerializer`.
-    init(host: String) {
-        self.host = host
+    init(hostHeaderValue: String) {
+        self.hostHeaderValue = hostHeaderValue
     }
     
     /// See `ChannelOutboundHandler`.
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let req = unwrapOutboundIn(data)
         var headers = req.headers
-        headers.add(name: .host, value: self.host)
+        headers.add(name: .host, value: self.hostHeaderValue)
         
         let path: String
         if let query = req.url.query {

--- a/Sources/HTTPKit/Client/HTTPClientRequestEncoder.swift
+++ b/Sources/HTTPKit/Client/HTTPClientRequestEncoder.swift
@@ -3,18 +3,18 @@ internal final class HTTPClientRequestEncoder: ChannelOutboundHandler, Removable
     typealias OutboundIn = HTTPRequest
     typealias OutboundOut = HTTPClientRequestPart
 
-    let hostname: String
+    let host: String
     
     /// Creates a new `HTTPClientRequestSerializer`.
-    init(hostname: String) {
-        self.hostname = hostname
+    init(host: String) {
+        self.host = host
     }
     
     /// See `ChannelOutboundHandler`.
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let req = unwrapOutboundIn(data)
         var headers = req.headers
-        headers.add(name: .host, value: self.hostname)
+        headers.add(name: .host, value: self.host)
         
         let path: String
         if let query = req.url.query {


### PR DESCRIPTION
When port is not the same as the standard port for the scheme, it must be specified in the HTTP `Host` header  (https://tools.ietf.org/html/rfc2616#section-14.23)