### PR TITLE
Stop overriding Host and User-Agent headers

### DIFF
--- a/Sources/HTTP/Responder/HTTPClient.swift
+++ b/Sources/HTTP/Responder/HTTPClient.swift
@@ -121,8 +121,12 @@ private final class HTTPClientRequestSerializer: ChannelOutboundHandler {
     func write(ctx: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
         let req = unwrapOutboundIn(data)
         var headers = req.headers
-        headers.add(name: .host, value: hostname)
-        headers.replaceOrAdd(name: .userAgent, value: "Vapor/3.0 (Swift)")
+        if !headers.contains(name: .host) {
+            headers.add(name: .host, value: hostname)
+        }
+        if !headers.contains(name: .userAgent) {
+            headers.add(name: .userAgent, value: "Vapor/3.0 (Swift)")
+        }
         var httpHead = HTTPRequestHead(version: req.version, method: req.method, uri: req.url.absoluteString)
         httpHead.headers = headers
         ctx.write(wrapOutboundOut(.head(httpHead)), promise: nil)

--- a/Sources/HTTP/Responder/HTTPClient.swift
+++ b/Sources/HTTP/Responder/HTTPClient.swift
@@ -102,10 +102,10 @@ public final class HTTPClient {
     }
 }
 
-// MARK: Internal
+// MARK: Private
 
 /// Private `ChannelOutboundHandler` that serializes `HTTPRequest` to `HTTPClientRequestPart`.
-final class HTTPClientRequestSerializer: ChannelOutboundHandler {
+private final class HTTPClientRequestSerializer: ChannelOutboundHandler {
     /// See `ChannelOutboundHandler`.
     typealias OutboundIn = HTTPRequest
 
@@ -150,8 +150,6 @@ final class HTTPClientRequestSerializer: ChannelOutboundHandler {
         return newHeaders
     }
 }
-
-// MARK: Private
 
 /// Private `ChannelInboundHandler` that parses `HTTPClientResponsePart` to `HTTPResponse`.
 private final class HTTPClientResponseParser: ChannelInboundHandler {


### PR DESCRIPTION
Vapor's HTTPClient implementation would previously always override the
Host and User-Agent headers when sending a request to the server. At
best this was undesired behaviour, at worst it would result in
HTTP 400 Bad Request responses.

Now, default values will only be provided if Host or User-Agent headers
were not already set.