### PR TITLE
Update the RFC1123 formatter with support for multiple locales

### DIFF
--- a/Sources/HTTPKit/Utilities/RFC1123.swift
+++ b/Sources/HTTPKit/Utilities/RFC1123.swift
@@ -28,8 +28,11 @@ private final class RFC1123 {
     /// Creates a new RFC1123 helper
     private init() {
         let formatter = DateFormatter()
+        let enUSPosixLocale = Locale(identifier: "en_US_POSIX")
+        formatter.locale = enUSPosixLocale
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+        formatter.calendar = Calendar(identifier: .gregorian)
         self.formatter = formatter
     }
     


### PR DESCRIPTION
Added more locale specific settings to support wider ranges of locales.
If the application containing the server would declare support for other locales, then the RFC1123 formatted string wouldn't be RFC compliant. This fix makes sure that the formatter always uses the enUS_POSIX locale and the Georgian calendar.