### PR TITLE
SameSite Attribute support none, default = lax

### DIFF
--- a/Sources/HTTP/Cookies/HTTPCookieValue.swift
+++ b/Sources/HTTP/Cookies/HTTPCookieValue.swift
@@ -107,7 +107,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
     ///     - path: The path at which the cookie is active. Defaults to `"/"`.
     ///     - isSecure: Limits the cookie to secure connections. Defaults to `false`.
     ///     - isHTTPOnly: Does not expose the cookie over non-HTTP channels. Defaults to `false`.
-    ///     - sameSite: See `HTTPSameSitePolicy`. Defaults to `nil`.
+    ///     - sameSite: See `HTTPSameSitePolicy`. Defaults to `lax`.
     public init(
         string: String,
         expires: Date? = nil,
@@ -116,7 +116,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
         path: String? = "/",
         isSecure: Bool = false,
         isHTTPOnly: Bool = false,
-        sameSite: HTTPSameSitePolicy = .lax
+        sameSite: HTTPSameSitePolicy? = nil
     ) {
         self.string = string
         self.expires = expires
@@ -125,7 +125,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
         self.path = path
         self.isSecure = isSecure
         self.isHTTPOnly = isHTTPOnly
-        self.sameSite = sameSite
+        self.sameSite = sameSite ?? .lax
     }
 
     /// See `ExpressibleByStringLiteral`.

--- a/Sources/HTTP/Cookies/HTTPCookieValue.swift
+++ b/Sources/HTTP/Cookies/HTTPCookieValue.swift
@@ -118,14 +118,16 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
         isHTTPOnly: Bool = false,
         sameSite: HTTPSameSitePolicy? = nil
     ) {
+        let sameSitePolicy = sameSite ?? .lax
+
         self.string = string
         self.expires = expires
         self.maxAge = maxAge
         self.domain = domain
         self.path = path
-        self.isSecure = isSecure
+        self.isSecure = isSecure || sameSitePolicy == .none //samesite none requires secure attribute to be set
         self.isHTTPOnly = isHTTPOnly
-        self.sameSite = sameSite ?? .lax
+        self.sameSite = sameSitePolicy
     }
 
     /// See `ExpressibleByStringLiteral`.

--- a/Sources/HTTP/Cookies/HTTPCookieValue.swift
+++ b/Sources/HTTP/Cookies/HTTPCookieValue.swift
@@ -37,7 +37,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
         var path: String?
         var secure = false
         var httpOnly = false
-        var sameSite: HTTPSameSitePolicy?
+        var sameSite: HTTPSameSitePolicy = .lax
 
         for (key, val) in header.parameters {
             switch key {
@@ -47,7 +47,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
             case "httponly": httpOnly = true
             case "secure": secure = true
             case "max-age": maxAge = Int(val) ?? 0
-            case "samesite": sameSite = HTTPSameSitePolicy(rawValue: val)
+            case "samesite": sameSite = HTTPSameSitePolicy(rawValue: val) ?? .lax
             default: break
             }
         }
@@ -91,7 +91,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
     /// A cookie which can only be sent in requests originating from the same origin as the target domain.
     ///
     /// This restriction mitigates attacks such as cross-site request forgery (XSRF).
-    public var sameSite: HTTPSameSitePolicy?
+    public var sameSite: HTTPSameSitePolicy
 
     // MARK: Init
 
@@ -116,7 +116,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
         path: String? = "/",
         isSecure: Bool = false,
         isHTTPOnly: Bool = false,
-        sameSite: HTTPSameSitePolicy? = nil
+        sameSite: HTTPSameSitePolicy = .lax
     ) {
         self.string = string
         self.expires = expires
@@ -163,14 +163,14 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
             serialized += "; HttpOnly"
         }
 
-        if let sameSite = self.sameSite {
-            serialized += "; SameSite"
-            switch sameSite {
-            case .lax:
-                serialized += "=Lax"
-            case .strict:
-                serialized += "=Strict"
-            }
+        serialized += "; SameSite"
+        switch sameSite {
+        case .lax:
+            serialized += "=Lax"
+        case .strict:
+            serialized += "=Strict"
+        case .lax:
+            serialized += "=None"
         }
 
         return serialized
@@ -184,4 +184,6 @@ public enum HTTPSameSitePolicy: String {
     case strict = "Strict"
     /// Relaxed mode.
     case lax = "Lax"
+    //The browser will send cookies with both cross-site requests and same-site requests.
+    case none = "None"
 }

--- a/Sources/HTTP/Cookies/HTTPCookieValue.swift
+++ b/Sources/HTTP/Cookies/HTTPCookieValue.swift
@@ -169,7 +169,7 @@ public struct HTTPCookieValue: ExpressibleByStringLiteral {
             serialized += "=Lax"
         case .strict:
             serialized += "=Strict"
-        case .lax:
+        case .none:
             serialized += "=None"
         }
 

--- a/Tests/HTTPTests/HTTPTests.swift
+++ b/Tests/HTTPTests/HTTPTests.swift
@@ -13,7 +13,7 @@ class HTTPTests: XCTestCase {
         XCTAssertEqual(value.expires, Date(rfc1123: "Wed, 21 Oct 2015 07:28:00 GMT"))
         XCTAssertEqual(value.isSecure, true)
         XCTAssertEqual(value.isHTTPOnly, true)
-        XCTAssertEqual(value.sameSite, HTTPSameSitePolicy.lax)
+        XCTAssertEqual(value.sameSite, .lax)
         
         guard let cookie: (name: String, value: HTTPCookieValue) = HTTPCookieValue.parse("vapor=; Secure; HttpOnly; SameSite=None") else {
             throw HTTPError(identifier: "cookie", reason: "Could not parse test cookie")
@@ -22,7 +22,28 @@ class HTTPTests: XCTestCase {
         XCTAssertEqual(cookie.value.string, "")
         XCTAssertEqual(cookie.value.isSecure, true)
         XCTAssertEqual(cookie.value.isHTTPOnly, true)
-        XCTAssertEqual(cookie.value.sameSite, HTTPSameSitePolicy.none)
+        XCTAssertEqual(cookie.value.sameSite, .none)
+    }
+    
+    func testCookieSameSiteAttribtue() throws {
+        let match = "id=cookie_data; Domain=example.com; Path=/; Secure; HttpOnly; SameSite=None"
+        
+        let value = HTTPCookieValue(string: "cookie_data", domain: "example.com", path: "/", isHTTPOnly: true, sameSite: .some(.none))
+        let serialized = value.serialize(name: "id")
+        
+        guard serialized == match else {
+            throw HTTPError(identifier: "cookie", reason: "Could not serialize test cookie")
+        }
+        
+        guard let cookie: (name: String, value: HTTPCookieValue) = HTTPCookieValue.parse(match) else {
+            throw HTTPError(identifier: "cookie", reason: "Could not parse test cookie")
+        }
+        
+        XCTAssertEqual(cookie.name, "id")
+        XCTAssertEqual(cookie.value.string, "cookie_data")
+        XCTAssertEqual(cookie.value.isSecure, true)
+        XCTAssertEqual(cookie.value.isHTTPOnly, true)
+        XCTAssertEqual(cookie.value.sameSite, .none)
     }
     
     func testCookieIsSerializedCorrectly() throws {
@@ -124,6 +145,7 @@ class HTTPTests: XCTestCase {
 
     static let allTests = [
         ("testCookieParse", testCookieParse),
+        ("testCookieSameSiteAttribtue", testCookieSameSiteAttribtue),
         ("testAcceptHeader", testAcceptHeader),
         ("testRemotePeer", testRemotePeer),
         ("testCookieIsSerializedCorrectly", testCookieIsSerializedCorrectly),

--- a/Tests/HTTPTests/HTTPTests.swift
+++ b/Tests/HTTPTests/HTTPTests.swift
@@ -2,6 +2,7 @@ import HTTP
 import XCTest
 
 class HTTPTests: XCTestCase {
+    
     func testCookieParse() throws {
         /// from https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
         guard let (name, value) = HTTPCookieValue.parse("id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly") else {
@@ -12,14 +13,16 @@ class HTTPTests: XCTestCase {
         XCTAssertEqual(value.expires, Date(rfc1123: "Wed, 21 Oct 2015 07:28:00 GMT"))
         XCTAssertEqual(value.isSecure, true)
         XCTAssertEqual(value.isHTTPOnly, true)
+        XCTAssertEqual(value.sameSite, HTTPSameSitePolicy.lax)
         
-        guard let cookie: (name: String, value: HTTPCookieValue) = HTTPCookieValue.parse("vapor=; Secure; HttpOnly") else {
+        guard let cookie: (name: String, value: HTTPCookieValue) = HTTPCookieValue.parse("vapor=; Secure; HttpOnly; SameSite=None") else {
             throw HTTPError(identifier: "cookie", reason: "Could not parse test cookie")
         }
         XCTAssertEqual(cookie.name, "vapor")
         XCTAssertEqual(cookie.value.string, "")
         XCTAssertEqual(cookie.value.isSecure, true)
         XCTAssertEqual(cookie.value.isHTTPOnly, true)
+        XCTAssertEqual(cookie.value.sameSite, HTTPSameSitePolicy.none)
     }
     
     func testCookieIsSerializedCorrectly() throws {


### PR DESCRIPTION
Adds the none attribute to SameSite cookies (#376). This resolves vapor/vapor#375.

⚠️ This contains an additional case in a public enum which may cause a breaking change if you're switching on it
